### PR TITLE
レスポンスのjsonをキャメルケースに変換する関数を作成

### DIFF
--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -6,9 +6,9 @@ export type Post = {
   url: string
   published: boolean
   evaluation: number
-  user_id: number
-  created_at: string
-  updated_at: string
+  userId: number
+  createdAt: string
+  updatedAt: string
 }
 
 export type PostResponse = Res<Post>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,5 @@
 import { isEmptyObj } from './isEmptyObj'
+import { toCamelCaseObj } from './toCamelCaseObj'
 
 export const BASE_URL = 'https://share-pos.herokuapp.com/api/v1'
 
@@ -41,7 +42,7 @@ export const fetchApi = async <T>(
     requestHeaders['Content-Type'] = 'application/json'
   }
 
-  let result
+  let result: object | undefined
   try {
     const res = await fetch(encodeURI(`${BASE_URL}${requestUrl}`), {
       method,
@@ -54,7 +55,7 @@ export const fetchApi = async <T>(
     if (!res.ok) {
       throw new HttpError(res)
     }
-    result = (await res.json()) as T
+    result = await res.json()
   } catch (error) {
     if (error instanceof HttpError) {
       throw error
@@ -62,7 +63,7 @@ export const fetchApi = async <T>(
     console.error(error)
   }
 
-  return result as T
+  return (result ? toCamelCaseObj(result) : result) as unknown as T
 }
 
 export const getApi = async <Data>(

--- a/src/utils/toCamelCaseObj.ts
+++ b/src/utils/toCamelCaseObj.ts
@@ -1,0 +1,32 @@
+// 文字列をスネークケースからキャメルケースに変換する関数
+export const toCamelCase = (str: string) => {
+  return str
+    .split('_')
+    .map((segment, i) =>
+      i === 0
+        ? segment.toLowerCase()
+        : segment[0].toUpperCase() + segment.slice(1).toLowerCase(),
+    )
+    .join('')
+}
+
+// objectのプロパティをスネークケースからキャメルケースに変換する関数
+export const toCamelCaseObj = (_obj: object) => {
+  const obj = { ..._obj } as Record<string, any>
+  const result: Record<string, Record<string, any> | []> = {}
+
+  Object.keys(obj).forEach((key) => {
+    if (typeof obj[key] !== 'object') {
+      result[toCamelCase(key)] = obj[key]
+      return
+    }
+
+    Array.isArray(obj[key])
+      ? (result[toCamelCase(key)] = obj[key].map((v: object) =>
+          toCamelCaseObj(v),
+        ))
+      : (result[toCamelCase(key)] = toCamelCaseObj(obj[key]))
+  })
+
+  return result
+}


### PR DESCRIPTION
## 関連 Issue

- #13 

## 詳細

- レスポンスのjsonをキャメルケースに変換する関数を作成（2次元配列は未対応）
- スネークケースになっていたところを修正

## 動作確認

- [x] レスポンスが全てキャメルケースに変換されていること
