### PR TITLE
PostItemのレイアウト作成

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,4 +11,5 @@ module.exports = {
     // qiita, zenn 以外は res.cloudinary.com
     domains: ['res.cloudinary.com', 'qiita-user-contents.imgix.net'],
   },
+  optimizeFonts: true,
 }

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -19,13 +19,12 @@ export const PostForm: FC<Props> = ({ onSubmit }) => {
       }}
     >
       <div>
-        <input
-          type='text'
+        <textarea
           value={comment}
           placeholder='comment'
           required
           onChange={(v) => setComment(v.target.value)}
-          className='border-black outline-none border-b-2 p-2'
+          className='border-black outline-none border-b-2 p-2 w-300px'
         />
       </div>
       <div>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -3,16 +3,14 @@ import Link from 'next/link'
 import { FC, useCallback, useState } from 'react'
 import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
-import { deleteApi, postApi } from 'utils/api'
+import { deleteApi } from 'utils/api'
 
 type Props = {
   post: Post
 }
 
 export const PostItem: FC<Props> = ({ post }) => {
-  // ・・・のボタン
   const [isOpenMenu, setIsOpenMenu] = useState(false)
-  // コメント全表示ボタン
   const [isOpenComment, setIsOpenComment] = useState(false)
   // 投稿の編集 commentだけでなく、オブジェクトでやるかも
   const [isEdit, setIsEdit] = useState(false)
@@ -21,13 +19,13 @@ export const PostItem: FC<Props> = ({ post }) => {
   const { cookies } = useCookies('authInfo')
 
   // params は postParams でまとめるかも urlは変える予定ない
-  const updatePost = useCallback(async (id: number, comment: string) => {
-    try {
-      const res = await postApi(`/posts/${id}`)
-    } catch (e) {
-      console.error(e)
-    }
-  }, [])
+  // const updatePost = useCallback(async (id: number, comment: string) => {
+  //   try {
+  //     const res = await postApi(`/posts/${id}`)
+  //   } catch (e) {
+  //     console.error(e)
+  //   }
+  // }, [])
 
   const deletePost = useCallback(
     async (id: number) => {
@@ -44,13 +42,13 @@ export const PostItem: FC<Props> = ({ post }) => {
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
       <div className='flex justify-between'>
         <div className='font-bold text-20px'>{post.user.username}</div>
-        {/* ・・・の投稿メニューボタン */}
-        <div
+        {/* 投稿メニューボタン */}
+        <button
           className='cursor-pointer text-23px duration-100 hover:opacity-50'
           onClick={() => setIsOpenMenu(!isOpenMenu)}
         >
           ・・・
-        </div>
+        </button>
       </div>
       {isOpenMenu && (
         <div>
@@ -80,22 +78,8 @@ export const PostItem: FC<Props> = ({ post }) => {
         </div>
       )}
 
-      {/* details メニューのパターン */}
-      {/* <details className='relative'>
-          <summary className='cursor-pointer list-none text-23px duration-100 hover:opacity-50'>
-            ・・・
-          </summary>
-          <div className='border bg-red-100 border-red-600 transform w-150px translate-x-[-160px] translate-y-[-20px] absolute'>
-            <div className='px-4 pt-2 hover:bg-red-500'>投稿を編集する</div>
-            <div className='px-4 pt-2 hover:bg-red-500'>
-              投稿を
-              <span className='font-bold text-red-500 text-18px'>削除</span>する
-            </div>
-            <div className='py-2 px-4 hover:bg-red-500'>フォルダに追加</div>
-          </div>
-        </details> */}
-
-      {/* 編集中ならtextarea それ以外は comment表示 */}
+      {/* 編集中ならtextarea それ以外は コメント表示 */}
+      {/* コメントは、overflow-scrollで、クリックで全文表示 */}
       {isEdit ? (
         <form>
           <div className='leading-1.4rem relative'>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -12,42 +12,36 @@ export const PostItem: FC<Props> = ({ post }) => {
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:h-350px sm:w-291px'>
       <div className='font-bold text-20px'>{post.user.username}</div>
       <div className='h-50px mt-1 overflow-hidden'>{post.comment}</div>
-      {/* <div className='w-80vw sm:w-full'> */}
-      <div className='duration-300 hover:opacity-70'>
-        {post.metaInfo && post.metaInfo.image && (
-          <Link href={post.url}>
-            <a target='_blank'>
-              <div className='flex text-blue-600 justify-end'>
-                ページを開く🔗
-              </div>
-              {/* <div className='w-80vw sm:w-full'> */}
-              {/* <div className='w-80vw w-max-80vw  sm:w-full'> */}
-              <div>
-                <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'>
-                  {/* <div className='flex rounded-10px h-43vw w-80vw overflow-hidden items-center sm:h-135px sm:w-256px'> */}
-                  {/* <div className='flex rounded-10px h-43vw overflow-hidden items-center sm:h-135px'> */}
 
-                  <Image
-                    src={
-                      post.metaInfo.image.substring(8, 18) === 'qiita-user' ||
-                      post.metaInfo.image.substring(8, 22) ===
-                        'res.cloudinary' ||
-                      post.metaInfo.image.substring(0, 21) ===
-                        'data:image/png;base64'
-                        ? post.metaInfo.image
-                        : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
-                    }
-                    alt=''
-                    className='rounded-10px transform duration-300 hover:scale-110'
-                    width={430}
-                    height={2260}
-                    objectFit='contain'
-                  />
+      <div className='duration-300 hover:opacity-70'>
+        <Link href={post.url}>
+          <a target='_blank'>
+            <div className='flex text-blue-600 justify-end'>ページを開く🔗</div>
+            <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'>
+              {post.metaInfo && typeof post.metaInfo.image === 'string' ? (
+                <Image
+                  src={
+                    post.metaInfo.image.substring(8, 18) === 'qiita-user' ||
+                    post.metaInfo.image.substring(8, 22) === 'res.cloudinary' ||
+                    post.metaInfo.image.substring(0, 21) ===
+                      'data:image/png;base64'
+                      ? post.metaInfo.image
+                      : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
+                  }
+                  alt=''
+                  className='rounded-10px transform duration-300 hover:scale-110'
+                  width={430}
+                  height={2260}
+                  objectFit='contain'
+                />
+              ) : (
+                <div className='flex h-full bg-gray-300 rounded-10px text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center hover:scale-110'>
+                  No image
                 </div>
-              </div>
-            </a>
-          </Link>
-        )}
+              )}
+            </div>
+          </a>
+        </Link>
       </div>
 
       <div className='flex'>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -9,43 +9,53 @@ type Props = {
 
 export const PostItem: FC<Props> = ({ post }) => {
   return (
-    <ul className='bg-white rounded-xl my-2 p-4'>
-      <li>{post.id}</li>
-      <li>{post.comment}</li>
-      <Link href={post.url}>
-        <a target='_blank' className='text-blue-500'>
-          {post.url}
-        </a>
-      </Link>
+    <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:h-350px sm:w-291px'>
+      <div className='font-bold text-20px'>{post.user.username}</div>
+      <div className='h-50px mt-1 overflow-hidden'>{post.comment}</div>
+      {/* <div className='w-80vw sm:w-full'> */}
+      <div className='duration-300 hover:opacity-70'>
+        {post.metaInfo && post.metaInfo.image && (
+          <Link href={post.url}>
+            <a target='_blank'>
+              <div className='flex text-blue-600 justify-end'>
+                ページを開く🔗
+              </div>
+              {/* <div className='w-80vw sm:w-full'> */}
+              {/* <div className='w-80vw w-max-80vw  sm:w-full'> */}
+              <div>
+                <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'>
+                  {/* <div className='flex rounded-10px h-43vw w-80vw overflow-hidden items-center sm:h-135px sm:w-256px'> */}
+                  {/* <div className='flex rounded-10px h-43vw overflow-hidden items-center sm:h-135px'> */}
 
-      <br></br>
-      {post.metaInfo.image.substring(8, 18) === 'qiita-user' ||
-      post.metaInfo.image.substring(8, 22) === 'res.cloudinary' ? (
-        // {/* next.config.js で増やしていく */}
-        <Image
-          src={post.metaInfo.image}
-          alt=''
-          width={300}
-          height={100}
-          objectFit='contain'
-        />
-      ) : (
-        // {/* Qiita, Zenn以外はこれで表示出来る */}
-        <Image
-          src={`https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`}
-          alt=''
-          width={300}
-          height={100}
-          objectFit='contain'
-        />
-      )}
+                  <Image
+                    src={
+                      post.metaInfo.image.substring(8, 18) === 'qiita-user' ||
+                      post.metaInfo.image.substring(8, 22) ===
+                        'res.cloudinary' ||
+                      post.metaInfo.image.substring(0, 21) ===
+                        'data:image/png;base64'
+                        ? post.metaInfo.image
+                        : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
+                    }
+                    alt=''
+                    className='rounded-10px transform duration-300 hover:scale-110'
+                    width={430}
+                    height={2260}
+                    objectFit='contain'
+                  />
+                </div>
+              </div>
+            </a>
+          </Link>
+        )}
+      </div>
+
       <div className='flex'>
         {[...Array(post.evaluation)].map((v, i) => (
           <div key={i}>☆</div>
         ))}
       </div>
-      <li>{post.createdAt}</li>
-      <li>{post.user.username}</li>
-    </ul>
+      <div className='flex justify-end'>{post.createdAt.substring(0, 10)}</div>
+    </div>
   )
 }

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -1,7 +1,9 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { FC, useState } from 'react'
+import { FC, useCallback, useState } from 'react'
+import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
+import { deleteApi } from 'utils/api'
 
 type Props = {
   post: Post
@@ -12,6 +14,21 @@ export const PostItem: FC<Props> = ({ post }) => {
   const [isOpenMenu, setIsOpenMenu] = useState(false)
   // コメント全表示ボタン
   const [isOpenComment, setIsOpenComment] = useState(false)
+  const [isEdit, setIsEdit] = useState(false)
+  const [comment, setComment] = useState(post.comment)
+
+  const { cookies } = useCookies('authInfo')
+
+  const deletePost = useCallback(
+    async (id: number) => {
+      try {
+        const res = await deleteApi(`posts/${id}`, {}, cookies.authInfo)
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    [cookies.authInfo],
+  )
 
   return (
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
@@ -31,8 +48,16 @@ export const PostItem: FC<Props> = ({ post }) => {
             onClick={() => setIsOpenMenu(false)}
             className='h-100vh opacity-25 top-0 left-0 w-100vw z-10 fixed'
           ></div>
-          <div className='border cursor-pointer bg-red-100 border-red-600 transform w-150px z-11 translate-x-220px translate-y-[-20px] absolute sm:(translate-x-60px translate-y-[-20px]) '>
-            <div className='px-4 pt-2 hover:bg-red-500'>投稿を編集する</div>
+          <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px transform w-150px z-11 translate-x-230px translate-y-[-20px] absolute sm:(translate-x-60px translate-y-[-20px]) '>
+            <div
+              className='px-4 pt-2 hover:bg-red-500'
+              onClick={() => {
+                setIsEdit(true)
+                setIsOpenMenu(false)
+              }}
+            >
+              投稿を編集する
+            </div>
             <div className='px-4 pt-2 hover:bg-red-500'>
               投稿を
               <span className='font-bold text-red-500 text-18px'>削除</span>
@@ -56,19 +81,45 @@ export const PostItem: FC<Props> = ({ post }) => {
           </div>
         </details> */}
 
-      <div
-        onClick={() => setIsOpenComment(!isOpenComment)}
-        className={`${
-          !isOpenComment && 'h-70px'
-        } min-h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap`}
-      >
-        <style jsx>{`
-          .scroll-bar::-webkit-scrollbar {
-            display: none;
-          }
-        `}</style>
-        {post.comment}
-      </div>
+      {isEdit ? (
+        <form>
+          <div className='leading-1.4rem relative'>
+            <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
+              {comment}
+            </div>
+            <textarea
+              className='h-full outline-none border-2 border-red-500 rounded-10px w-full p-2 top-0 left-0 scroll-bar absolute'
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+            />
+          </div>
+          <div className='flex mt-4 gap-3 justify-end'>
+            <button
+              className='border border-red-500'
+              onClick={() => setIsEdit(false)}
+            >
+              キャンセル
+            </button>
+            <button className='border border-red-500'>更新</button>
+          </div>
+        </form>
+      ) : (
+        <div
+          onClick={() => setIsOpenComment(!isOpenComment)}
+          className={`${
+            !isOpenComment && 'h-70px'
+          } min-h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap`}
+        >
+          {post.comment}
+        </div>
+      )}
+
+      {/* スクロールバーを消す */}
+      <style jsx>{`
+        .scroll-bar::-webkit-scrollbar {
+          display: none;
+        }
+      `}</style>
 
       {/* <div className='h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap'>
         <style jsx>{`

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 import { FC, useCallback, useState } from 'react'
 import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
-import { deleteApi } from 'utils/api'
 
 type Props = {
   post: Post
@@ -18,6 +17,10 @@ export const PostItem: FC<Props> = ({ post }) => {
 
   const { cookies } = useCookies('authInfo')
 
+  const pickDomainFromURL = useCallback((url: string) => {
+    return url.split('//')[1].split('/')[0]
+  }, [])
+
   // params は postParams でまとめるかも urlは変える予定ない
   // const updatePost = useCallback(async (id: number, comment: string) => {
   //   try {
@@ -27,16 +30,16 @@ export const PostItem: FC<Props> = ({ post }) => {
   //   }
   // }, [])
 
-  const deletePost = useCallback(
-    async (id: number) => {
-      try {
-        const res = await deleteApi(`posts/${id}`, {}, cookies.authInfo)
-      } catch (e) {
-        console.error(e)
-      }
-    },
-    [cookies.authInfo],
-  )
+  // const deletePost = useCallback(
+  //   async (id: number) => {
+  //     try {
+  //       const res = await deleteApi(`posts/${id}`, {}, cookies.authInfo)
+  //     } catch (e) {
+  //       console.error(e)
+  //     }
+  //   },
+  //   [cookies.authInfo],
+  // )
 
   return (
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
@@ -109,9 +112,16 @@ export const PostItem: FC<Props> = ({ post }) => {
           onClick={() => setIsOpenComment(!isOpenComment)}
           className={`${
             !isOpenComment && 'h-70px'
-          } min-h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap`}
+          } min-h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap group relative`}
         >
           {post.comment}
+          <div
+            className={`bg-red-200 bg-opacity-70 text-center w-full py-2 top-30px absolute invisible ${
+              !isOpenComment && 'group-hover:visible'
+            }`}
+          >
+            もっとみる
+          </div>
         </div>
       )}
 
@@ -125,11 +135,20 @@ export const PostItem: FC<Props> = ({ post }) => {
       {/* 画像ないなら No image */}
       {/* 画像がQiita, Zenn, Instagram ならそのまま表示 */}
       {/* 上が違うなら、res.cloudinaryのfetchで表示 */}
-      <div>
+      <article className='border-2 rounded-10px mt-2 p-2 duration-300 group hover:bg-gray-100 '>
         <Link href={post.url}>
           <a target='_blank'>
-            <div className='flex text-blue-600 justify-end'>ページを開く🔗</div>
-            <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'>
+            <div className='h-45px overflow-hidden group-hover:underline'>
+              <>
+                {post.metaInfo && typeof post.metaInfo.image === 'string' ? (
+                  post.metaInfo.title
+                ) : (
+                  <div className='flex justify-end'>ページを開く🔗</div>
+                )}
+              </>
+            </div>
+            {/* <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'> */}
+            <div className='flex rounded-10px h-42vw mt-3.5 max-h-215px overflow-hidden items-center sm:h-126px'>
               {post.metaInfo && typeof post.metaInfo.image === 'string' ? (
                 <Image
                   src={
@@ -141,20 +160,21 @@ export const PostItem: FC<Props> = ({ post }) => {
                       : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
                   }
                   alt=''
-                  className='rounded-10px transform duration-300 hover:scale-105'
+                  className='rounded-10px transform duration-300 group-hover:scale-105'
                   width={430}
                   height={2260}
                   objectFit='contain'
                 />
               ) : (
-                <div className='flex h-full bg-gray-300 rounded-10px text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center hover:scale-110'>
+                <div className='flex h-full bg-gray-300 rounded-10px text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
                   No image
                 </div>
               )}
             </div>
+            <p>{pickDomainFromURL(post.url)}</p>
           </a>
         </Link>
-      </div>
+      </article>
 
       <div className='flex'>
         {[...Array(post.evaluation)].map((v, i) => (

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -78,7 +78,7 @@ export const PostItem: FC<Props> = ({ post }) => {
 
   return (
     <article className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
-      <section className='flex justify-between'>
+      <div className='flex justify-between'>
         <div className='font-bold text-20px'>{post.user.username}</div>
         {/* 投稿メニューボタン */}
         <button
@@ -87,9 +87,9 @@ export const PostItem: FC<Props> = ({ post }) => {
         >
           ・・・
         </button>
-      </section>
+      </div>
       {isOpenMenu && (
-        <nav>
+        <div>
           <div
             onClick={() => setIsOpenMenu(false)}
             className='h-100vh opacity-25 top-0 left-0 w-100vw z-10 fixed'
@@ -116,70 +116,67 @@ export const PostItem: FC<Props> = ({ post }) => {
               フォルダに追加
             </div>
           </div>
-        </nav>
+        </div>
       )}
 
       {/* 編集中ならtextarea それ以外は コメント表示 */}
-      <section>
-        {isEdit ? (
-          <form>
-            <div className='leading-1.4rem relative'>
-              <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
-                {comment}
-              </div>
-              <textarea
-                className='border h-full outline-none border-red-500 rounded-10px w-full p-2 top-0 left-0 absolute'
-                value={comment}
-                onChange={(e) => setComment(e.target.value)}
-              />
+      {isEdit ? (
+        <form>
+          <div className='leading-1.4rem relative'>
+            <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
+              {comment}
             </div>
-            <div className='flex mt-4 gap-3 justify-end'>
-              <button
-                className='border border-gray-500 py-1 px-2 text-gray-500 duration-300 hover:(bg-gray-500 text-white rounded-10px) '
-                onClick={() => setIsEdit(false)}
-              >
-                キャンセル
-              </button>
-              <button className='border bg-red-500 border-red-500 text-white py-1 px-2 duration-300 hover:(bg-white text-red-500 rounded-10px) '>
-                更新
-              </button>
-            </div>
-          </form>
-        ) : (
-          <div
-            onClick={() =>
-              hasElment3MoreThanLines && setIsOpenComment(!isOpenComment)
-            }
-            className={`${
-              !isOpenComment && 'h-70px'
-            } mt-3 overflow-hidden whitespace-pre-wrap group relative`}
-          >
-            <div ref={commentRef} className='h-auto'>
-              {post.comment}
-            </div>
-            <div
-              className={`bg-red-200 bg-opacity-70 text-center w-full py-2 top-30px absolute ${
-                showSeeMore
-                  ? 'visible sm:invisible sm:group-hover:visible'
-                  : 'invisible'
-              }`}
-            >
-              もっとみる
-            </div>
+            <textarea
+              className='border h-full outline-none border-red-500 rounded-10px w-full p-2 top-0 left-0 absolute'
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+            />
           </div>
-        )}
-      </section>
+          <div className='flex mt-4 gap-3 justify-end'>
+            <button
+              className='border border-gray-500 py-1 px-2 text-gray-500 duration-300 hover:(bg-gray-500 text-white rounded-10px) '
+              onClick={() => setIsEdit(false)}
+            >
+              キャンセル
+            </button>
+            <button className='border bg-red-500 border-red-500 text-white py-1 px-2 duration-300 hover:(bg-white text-red-500 rounded-10px) '>
+              更新
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div
+          onClick={() =>
+            hasElment3MoreThanLines && setIsOpenComment(!isOpenComment)
+          }
+          className={`${
+            !isOpenComment && 'h-70px'
+          } mt-3 overflow-hidden whitespace-pre-wrap group relative`}
+        >
+          <div ref={commentRef} className='h-auto'>
+            {post.comment}
+          </div>
+          <div
+            className={`bg-red-200 bg-opacity-70 text-center w-full py-2 top-30px absolute ${
+              showSeeMore
+                ? 'visible sm:invisible sm:group-hover:visible'
+                : 'invisible'
+            }`}
+          >
+            もっとみる
+          </div>
+        </div>
+      )}
 
       <figure className='border-2 rounded-10px mt-2 duration-300 group hover:bg-gray-100 '>
         <Link href={post.url}>
           <a target='_blank'>
-            {/* // <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'> */}
             <div className='flex rounded-t-10px h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
               {post.metaInfo.image ? (
                 <Image
                   src={determineUrlByDomain(post.metaInfo.image)}
                   alt=''
-                  className='bg-gray-100 rounded-10px transform duration-300 group-hover:scale-105'
+                  className='bg-gray-100 rounded-10px transform duration-300 group-hover:scale-110'
                   width={430}
                   height={2000}
                   objectFit='contain'
@@ -194,7 +191,7 @@ export const PostItem: FC<Props> = ({ post }) => {
               <p className='text-13px text-gray-500'>
                 {pickDomainFromURL(post.url)}
               </p>
-              <div className='h-37px mt-2 text-sm overflow-hidden group-hover:underline'>
+              <div className='h-37px mt-2 text-sm overflow-hidden'>
                 {post.metaInfo.title}
               </div>
             </figcaption>
@@ -202,14 +199,14 @@ export const PostItem: FC<Props> = ({ post }) => {
         </Link>
       </figure>
 
-      <section className='flex mt-1 items-center justify-between'>
+      <div className='flex mt-1 items-center justify-between'>
         <div className='flex'>
           {[...Array(post.evaluation)].map((v, i) => (
             <div key={i}>☆</div>
           ))}
         </div>
         <div className='text-13px'>{post.createdAt.substring(0, 10)}</div>
-      </section>
+      </div>
     </article>
   )
 }

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -8,12 +8,16 @@ type Props = {
 }
 
 export const PostItem: FC<Props> = ({ post }) => {
+  // ・・・のボタン
   const [isOpenMenu, setIsOpenMenu] = useState(false)
+  // コメント全表示ボタン
+  const [isOpenComment, setIsOpenComment] = useState(false)
 
   return (
-    <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:h-350px sm:w-291px'>
+    <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
       <div className='flex justify-between'>
         <div className='font-bold text-20px'>{post.user.username}</div>
+        {/* ・・・のボタン */}
         <div
           className='cursor-pointer text-23px duration-100 hover:opacity-50'
           onClick={() => setIsOpenMenu(!isOpenMenu)}
@@ -51,10 +55,29 @@ export const PostItem: FC<Props> = ({ post }) => {
             <div className='py-2 px-4 hover:bg-red-500'>フォルダに追加</div>
           </div>
         </details> */}
-      {/* <div className='h-70px mt-3 overflow-hidden whitespace-pre-wrap'> */}
-      <div className='h-70px mt-3 overflow-y-scroll whitespace-pre-wrap'>
+
+      <div
+        onClick={() => setIsOpenComment(!isOpenComment)}
+        className={`${
+          !isOpenComment && 'h-70px'
+        } min-h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap`}
+      >
+        <style jsx>{`
+          .scroll-bar::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
         {post.comment}
       </div>
+
+      {/* <div className='h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap'>
+        <style jsx>{`
+          .scroll-bar::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
+        {post.comment}
+      </div> */}
 
       <div>
         <Link href={post.url}>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { FC, useCallback, useState } from 'react'
 import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
-import { deleteApi } from 'utils/api'
+import { deleteApi, postApi } from 'utils/api'
 
 type Props = {
   post: Post
@@ -14,10 +14,20 @@ export const PostItem: FC<Props> = ({ post }) => {
   const [isOpenMenu, setIsOpenMenu] = useState(false)
   // コメント全表示ボタン
   const [isOpenComment, setIsOpenComment] = useState(false)
+  // 投稿の編集 commentだけでなく、オブジェクトでやるかも
   const [isEdit, setIsEdit] = useState(false)
   const [comment, setComment] = useState(post.comment)
 
   const { cookies } = useCookies('authInfo')
+
+  // params は postParams でまとめるかも urlは変える予定ない
+  const updatePost = useCallback(async (id: number, comment: string) => {
+    try {
+      const res = await postApi(`/posts/${id}`)
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
 
   const deletePost = useCallback(
     async (id: number) => {
@@ -34,7 +44,7 @@ export const PostItem: FC<Props> = ({ post }) => {
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
       <div className='flex justify-between'>
         <div className='font-bold text-20px'>{post.user.username}</div>
-        {/* ・・・のボタン */}
+        {/* ・・・の投稿メニューボタン */}
         <div
           className='cursor-pointer text-23px duration-100 hover:opacity-50'
           onClick={() => setIsOpenMenu(!isOpenMenu)}
@@ -69,6 +79,8 @@ export const PostItem: FC<Props> = ({ post }) => {
           </div>
         </div>
       )}
+
+      {/* details メニューのパターン */}
       {/* <details className='relative'>
           <summary className='cursor-pointer list-none text-23px duration-100 hover:opacity-50'>
             ・・・
@@ -83,26 +95,27 @@ export const PostItem: FC<Props> = ({ post }) => {
           </div>
         </details> */}
 
+      {/* 編集中ならtextarea それ以外は comment表示 */}
       {isEdit ? (
         <form>
           <div className='leading-1.4rem relative'>
-            <div className='py-6 px-2 invisible whitespace-pre-wrap break-words'>
+            <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
               {comment}
             </div>
             <textarea
-              className='h-full outline-none border-2 border-red-500 rounded-10px w-full p-2 top-0 left-0 scroll-bar absolute'
+              className='border h-full outline-none border-red-500 rounded-10px w-full p-2 top-0 left-0 scroll-bar absolute'
               value={comment}
               onChange={(e) => setComment(e.target.value)}
             />
           </div>
           <div className='flex mt-4 gap-3 justify-end'>
             <button
-              className='border border-red-500 rounded-10px py-1 px-2 text-red-500 duration-300 hover:(bg-red-500 text-white rounded-none) '
+              className='border border-gray-500 py-1 px-2 text-gray-500 duration-300 hover:(bg-gray-500 text-white rounded-10px) '
               onClick={() => setIsEdit(false)}
             >
               キャンセル
             </button>
-            <button className='border border-red-500 rounded-10px py-1 px-2 text-red-500 duration-300 hover:(bg-red-500 text-white rounded-none) '>
+            <button className='border bg-red-500 border-red-500 text-white py-1 px-2 duration-300 hover:(bg-white text-red-500 rounded-10px) '>
               更新
             </button>
           </div>
@@ -125,15 +138,9 @@ export const PostItem: FC<Props> = ({ post }) => {
         }
       `}</style>
 
-      {/* <div className='h-70px mt-3 scroll-bar overflow-y-scroll whitespace-pre-wrap'>
-        <style jsx>{`
-          .scroll-bar::-webkit-scrollbar {
-            display: none;
-          }
-        `}</style>
-        {post.comment}
-      </div> */}
-
+      {/* 画像ないなら No image */}
+      {/* 画像がQiita, Zenn, Instagram ならそのまま表示 */}
+      {/* 上が違うなら、res.cloudinaryのfetchで表示 */}
       <div>
         <Link href={post.url}>
           <a target='_blank'>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -33,11 +33,7 @@ export const PostItem: FC<Props> = ({ post }) => {
   const deletePost = useCallback(
     async (id: number) => {
       try {
-        const res = await deleteApi(
-          `/posts/${String(id)}`,
-          undefined,
-          cookies.authInfo,
-        )
+        const res = await deleteApi(`/posts/${id}`, undefined, cookies.authInfo)
         if (!posts) {
           return
         }
@@ -81,8 +77,8 @@ export const PostItem: FC<Props> = ({ post }) => {
   )
 
   return (
-    <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
-      <div className='flex justify-between'>
+    <article className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:w-291px'>
+      <section className='flex justify-between'>
         <div className='font-bold text-20px'>{post.user.username}</div>
         {/* 投稿メニューボタン */}
         <button
@@ -91,9 +87,9 @@ export const PostItem: FC<Props> = ({ post }) => {
         >
           ・・・
         </button>
-      </div>
+      </section>
       {isOpenMenu && (
-        <div>
+        <nav>
           <div
             onClick={() => setIsOpenMenu(false)}
             className='h-100vh opacity-25 top-0 left-0 w-100vw z-10 fixed'
@@ -120,59 +116,61 @@ export const PostItem: FC<Props> = ({ post }) => {
               フォルダに追加
             </div>
           </div>
-        </div>
+        </nav>
       )}
 
       {/* 編集中ならtextarea それ以外は コメント表示 */}
-      {isEdit ? (
-        <form>
-          <div className='leading-1.4rem relative'>
-            <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
-              {comment}
+      <section>
+        {isEdit ? (
+          <form>
+            <div className='leading-1.4rem relative'>
+              <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
+                {comment}
+              </div>
+              <textarea
+                className='border h-full outline-none border-red-500 rounded-10px w-full p-2 top-0 left-0 absolute'
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+              />
             </div>
-            <textarea
-              className='border h-full outline-none border-red-500 rounded-10px w-full p-2 top-0 left-0 absolute'
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-            />
-          </div>
-          <div className='flex mt-4 gap-3 justify-end'>
-            <button
-              className='border border-gray-500 py-1 px-2 text-gray-500 duration-300 hover:(bg-gray-500 text-white rounded-10px) '
-              onClick={() => setIsEdit(false)}
-            >
-              キャンセル
-            </button>
-            <button className='border bg-red-500 border-red-500 text-white py-1 px-2 duration-300 hover:(bg-white text-red-500 rounded-10px) '>
-              更新
-            </button>
-          </div>
-        </form>
-      ) : (
-        <div
-          onClick={() =>
-            hasElment3MoreThanLines && setIsOpenComment(!isOpenComment)
-          }
-          className={`${
-            !isOpenComment && 'h-70px'
-          } mt-3 overflow-hidden whitespace-pre-wrap group relative`}
-        >
-          <div ref={commentRef} className='h-auto'>
-            {post.comment}
-          </div>
+            <div className='flex mt-4 gap-3 justify-end'>
+              <button
+                className='border border-gray-500 py-1 px-2 text-gray-500 duration-300 hover:(bg-gray-500 text-white rounded-10px) '
+                onClick={() => setIsEdit(false)}
+              >
+                キャンセル
+              </button>
+              <button className='border bg-red-500 border-red-500 text-white py-1 px-2 duration-300 hover:(bg-white text-red-500 rounded-10px) '>
+                更新
+              </button>
+            </div>
+          </form>
+        ) : (
           <div
-            className={`bg-red-200 bg-opacity-70 text-center w-full py-2 top-30px absolute ${
-              showSeeMore
-                ? 'visible sm:invisible sm:group-hover:visible'
-                : 'invisible'
-            }`}
+            onClick={() =>
+              hasElment3MoreThanLines && setIsOpenComment(!isOpenComment)
+            }
+            className={`${
+              !isOpenComment && 'h-70px'
+            } mt-3 overflow-hidden whitespace-pre-wrap group relative`}
           >
-            もっとみる
+            <div ref={commentRef} className='h-auto'>
+              {post.comment}
+            </div>
+            <div
+              className={`bg-red-200 bg-opacity-70 text-center w-full py-2 top-30px absolute ${
+                showSeeMore
+                  ? 'visible sm:invisible sm:group-hover:visible'
+                  : 'invisible'
+              }`}
+            >
+              もっとみる
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </section>
 
-      <article className='border-2 rounded-10px mt-2 duration-300 group hover:bg-gray-100 '>
+      <figure className='border-2 rounded-10px mt-2 duration-300 group hover:bg-gray-100 '>
         <Link href={post.url}>
           <a target='_blank'>
             {/* // <div className='flex rounded-10px h-42vw max-h-225px overflow-hidden items-center sm:h-135px'> */}
@@ -192,26 +190,26 @@ export const PostItem: FC<Props> = ({ post }) => {
                 </div>
               )}
             </div>
-            <div className='p-2'>
+            <figcaption className='p-2'>
               <p className='text-13px text-gray-500'>
                 {pickDomainFromURL(post.url)}
               </p>
               <div className='h-37px mt-2 text-sm overflow-hidden group-hover:underline'>
                 {post.metaInfo.title}
               </div>
-            </div>
+            </figcaption>
           </a>
         </Link>
-      </article>
+      </figure>
 
-      <div className='flex mt-1 items-center justify-between'>
+      <section className='flex mt-1 items-center justify-between'>
         <div className='flex'>
           {[...Array(post.evaluation)].map((v, i) => (
             <div key={i}>☆</div>
           ))}
         </div>
         <div className='text-13px'>{post.createdAt.substring(0, 10)}</div>
-      </div>
-    </div>
+      </section>
+    </article>
   )
 }

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { Post } from 'types/post'
 
 type Props = {
@@ -8,14 +8,55 @@ type Props = {
 }
 
 export const PostItem: FC<Props> = ({ post }) => {
+  const [isOpenMenu, setIsOpenMenu] = useState(false)
+
   return (
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:h-350px sm:w-291px'>
-      <div className='font-bold text-20px'>{post.user.username}</div>
-      <div className='h-50px mt-1 overflow-hidden whitespace-pre-wrap'>
+      <div className='flex justify-between'>
+        <div className='font-bold text-20px'>{post.user.username}</div>
+        <div
+          className='cursor-pointer text-23px duration-100 hover:opacity-50'
+          onClick={() => setIsOpenMenu(!isOpenMenu)}
+        >
+          ・・・
+        </div>
+      </div>
+      {isOpenMenu && (
+        <div>
+          <div
+            onClick={() => setIsOpenMenu(false)}
+            className='h-100vh opacity-25 top-0 left-0 w-100vw z-10 fixed'
+          ></div>
+          <div className='border cursor-pointer bg-red-100 border-red-600 transform w-150px z-11 translate-x-220px translate-y-[-20px] absolute sm:(translate-x-60px translate-y-[-20px]) '>
+            <div className='px-4 pt-2 hover:bg-red-500'>投稿を編集する</div>
+            <div className='px-4 pt-2 hover:bg-red-500'>
+              投稿を
+              <span className='font-bold text-red-500 text-18px'>削除</span>
+              する
+            </div>
+            <div className='py-2 px-4 hover:bg-red-500'>フォルダに追加</div>
+          </div>
+        </div>
+      )}
+      {/* <details className='relative'>
+          <summary className='cursor-pointer list-none text-23px duration-100 hover:opacity-50'>
+            ・・・
+          </summary>
+          <div className='border bg-red-100 border-red-600 transform w-150px translate-x-[-160px] translate-y-[-20px] absolute'>
+            <div className='px-4 pt-2 hover:bg-red-500'>投稿を編集する</div>
+            <div className='px-4 pt-2 hover:bg-red-500'>
+              投稿を
+              <span className='font-bold text-red-500 text-18px'>削除</span>する
+            </div>
+            <div className='py-2 px-4 hover:bg-red-500'>フォルダに追加</div>
+          </div>
+        </details> */}
+      {/* <div className='h-70px mt-3 overflow-hidden whitespace-pre-wrap'> */}
+      <div className='h-70px mt-3 overflow-y-scroll whitespace-pre-wrap'>
         {post.comment}
       </div>
 
-      <div className='duration-300 hover:opacity-70'>
+      <div>
         <Link href={post.url}>
           <a target='_blank'>
             <div className='flex text-blue-600 justify-end'>ページを開く🔗</div>
@@ -31,7 +72,7 @@ export const PostItem: FC<Props> = ({ post }) => {
                       : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
                   }
                   alt=''
-                  className='rounded-10px transform duration-300 hover:scale-110'
+                  className='rounded-10px transform duration-300 hover:scale-105'
                   width={430}
                   height={2260}
                   objectFit='contain'

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -11,7 +11,9 @@ export const PostItem: FC<Props> = ({ post }) => {
   return (
     <div className='bg-white rounded-xl my-2 max-w-460px p-4 w-90vw sm:h-350px sm:w-291px'>
       <div className='font-bold text-20px'>{post.user.username}</div>
-      <div className='h-50px mt-1 overflow-hidden'>{post.comment}</div>
+      <div className='h-50px mt-1 overflow-hidden whitespace-pre-wrap'>
+        {post.comment}
+      </div>
 
       <div className='duration-300 hover:opacity-70'>
         <Link href={post.url}>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -50,7 +50,7 @@ export const PostItem: FC<Props> = ({ post }) => {
           ></div>
           <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px transform w-150px z-11 translate-x-230px translate-y-[-20px] absolute sm:(translate-x-60px translate-y-[-20px]) '>
             <div
-              className='px-4 pt-2 hover:bg-red-500'
+              className='rounded-t-10px px-4 pt-2 hover:bg-red-300'
               onClick={() => {
                 setIsEdit(true)
                 setIsOpenMenu(false)
@@ -58,12 +58,14 @@ export const PostItem: FC<Props> = ({ post }) => {
             >
               投稿を編集する
             </div>
-            <div className='px-4 pt-2 hover:bg-red-500'>
+            <div className='px-4 pt-2 hover:bg-red-300'>
               投稿を
               <span className='font-bold text-red-500 text-18px'>削除</span>
               する
             </div>
-            <div className='py-2 px-4 hover:bg-red-500'>フォルダに追加</div>
+            <div className='rounded-b-10px py-2 px-4 hover:bg-red-300'>
+              フォルダに追加
+            </div>
           </div>
         </div>
       )}
@@ -84,7 +86,7 @@ export const PostItem: FC<Props> = ({ post }) => {
       {isEdit ? (
         <form>
           <div className='leading-1.4rem relative'>
-            <div className='py-4 px-2 invisible whitespace-pre-wrap break-words'>
+            <div className='py-6 px-2 invisible whitespace-pre-wrap break-words'>
               {comment}
             </div>
             <textarea
@@ -95,12 +97,14 @@ export const PostItem: FC<Props> = ({ post }) => {
           </div>
           <div className='flex mt-4 gap-3 justify-end'>
             <button
-              className='border border-red-500'
+              className='border border-red-500 rounded-10px py-1 px-2 text-red-500 duration-300 hover:(bg-red-500 text-white rounded-none) '
               onClick={() => setIsEdit(false)}
             >
               キャンセル
             </button>
-            <button className='border border-red-500'>更新</button>
+            <button className='border border-red-500 rounded-10px py-1 px-2 text-red-500 duration-300 hover:(bg-red-500 text-white rounded-none) '>
+              更新
+            </button>
           </div>
         </form>
       ) : (

--- a/src/components/post/PostItemList.tsx
+++ b/src/components/post/PostItemList.tsx
@@ -1,24 +1,11 @@
 import { FC, ReactNode } from 'react'
-import { useCookies } from 'stores/useCookies'
-import { deleteApi } from 'utils/api'
 
 type Props = {
   children: ReactNode[]
 }
 
 export const PostItemList: FC<Props> = ({ children }) => {
-  const { cookies } = useCookies('authInfo')
-  const Click = async () => {
-    try {
-      const res = await deleteApi('/posts/103', undefined, cookies.authInfo)
-      console.log(res)
-    } catch (e) {
-      console.log(e)
-    }
-  }
-
   return (
-    // <ul className='flex flex-col sm:(flex flex-wrap) '>
     <ul className='flex flex-wrap gap-6 justify-center'>
       {children.map((post, i) => (
         <li className='w-100%' key={i}>

--- a/src/components/post/PostItemList.tsx
+++ b/src/components/post/PostItemList.tsx
@@ -1,0 +1,30 @@
+import { FC, ReactNode } from 'react'
+import { useCookies } from 'stores/useCookies'
+import { deleteApi } from 'utils/api'
+
+type Props = {
+  children: ReactNode[]
+}
+
+export const PostItemList: FC<Props> = ({ children }) => {
+  const { cookies } = useCookies('authInfo')
+  const Click = async () => {
+    try {
+      const res = await deleteApi('/posts/103', undefined, cookies.authInfo)
+      console.log(res)
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  return (
+    // <ul className='flex flex-col sm:(flex flex-wrap) '>
+    <ul className='flex flex-wrap gap-6 justify-center'>
+      {children.map((post, i) => (
+        <li className='w-100%' key={i}>
+          {post}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -9,7 +9,7 @@ export const Header: FC = () => {
 
   return (
     <>
-      <header className='bg-red-100 shadow-md w-full top-0 shadow-red-100 fixed'>
+      <header className='bg-white w-full py-2 top-0 z-10 fixed'>
         <nav className='flex mx-4 items-center justify-between'>
           <Link href='/'>
             <div className='cursor-pointer mt-0 mb-1  text-6xl text-red-500'>

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -7,13 +7,11 @@ type Props = {
 
 export const Layout: FC<Props> = ({ children }) => {
   return (
-    <div className='min-h-full'>
+    <>
       <Header />
-      <div className='mx-4 mt-25 overflow-hidden'>
-        <div className='mx-auto bg-red-100 max-w-600px p-4 break-words'>
-          {children}
-        </div>
+      <div className='bg-red-100 min-h-100vh pt-25 overflow-hidden '>
+        <div className='mx-auto max-w-1000px px-2 break-words'>{children}</div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -9,9 +9,9 @@ export const Layout: FC<Props> = ({ children }) => {
   return (
     <>
       <Header />
-      <div className='bg-red-100 min-h-100vh pt-25 overflow-hidden '>
+      <main className='bg-red-100 min-h-100vh pt-25 overflow-hidden '>
         <div className='mx-auto max-w-1000px px-2 break-words'>{children}</div>
-      </div>
+      </main>
     </>
   )
 }

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -44,19 +44,6 @@ const Create: NextPage = () => {
         <div>
           <h1>Post Create</h1>
           <PostForm onSubmit={onSubmit} />
-          {/* <div>
-            {posts?.length &&
-              posts
-                .map((_, i, a) => a[a.length - 1 - i])
-                .map((v, i) => (
-                  <ul key={i} className='mt-3'>
-                    <li>{v.comment}</li>
-                    <li>{v.url}</li>
-                    <li>{v.comment}</li>
-                  </ul>
-                ))}
-          </div>
-          <div>{JSON.stringify(posts)}</div> */}
         </div>
       </Layout>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next'
 import Head from 'next/head'
 import { PostItem } from 'components/post/PostItem'
+import { PostItemList } from 'components/post/PostItemList'
 import { Layout } from 'components/shared/Layout'
 import { useGetApi } from 'hooks/useApi'
 import { useCookies } from 'stores/useCookies'
@@ -21,10 +22,13 @@ const Home: NextPage = () => {
         <title>SharePos 投稿一覧ページ</title>
       </Head>
       <Layout>
-        <div className='sm:(flex flex-wrap justify-around) '>
-          {posts.length &&
-            posts.map((post, i) => <PostItem post={post} key={i} />)}
-        </div>
+        {posts.length && (
+          <PostItemList>
+            {posts.map((post, i) => (
+              <PostItem post={post} key={i} />
+            ))}
+          </PostItemList>
+        )}
       </Layout>
     </>
   )

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -11,7 +11,7 @@ export type Post = {
     username: string
   }
   metaInfo: {
-    image: string
+    image: string | undefined
     title: string
   }
 }


### PR DESCRIPTION

## 詳細
画像のアスペクト比を保って、長方形の形になるよう表示
- Qiita, Zennに合わせた縦横比
- 横幅を揃えて、縦は横幅に対応する高さにし、親divのoverflow-hidden と items-center でサイズを固定
- ホバーで、opacityとscale

コメント
- コメントの高さを固定する
- コメントをクリックする前で、コメントをscroll-yしている
- コメントをクリックすると、全文表示する

・・・のメニュー
- 押すと、「編集」、「削除」、「フォルダに追加」が表示される
- 「編集」を押した処理だけ書いている。
- 「編集」を押すと、コメントが表示されていた個所が textarea になる。
- textare を absolute、親をrelative にして、同じ子要素でコメントをinvisibleで表示することで、textareaの高さが可変する。
- 「編集」の更新は出来ない

## 動作確認
３列の時
![スクリーンショット 2022-07-24 110230](https://user-images.githubusercontent.com/88410576/180648497-09425934-8cde-43f2-ab93-727be5daf879.png)


![スクリーンショット 2022-07-24 110243](https://user-images.githubusercontent.com/88410576/180648506-4110d63d-419d-4963-a00d-9327f0037aab.png)


文字数が多い時、コメントをクリックで下の画像になる
![スクリーンショット 2022-07-24 163256](https://user-images.githubusercontent.com/88410576/180648443-d5ed4376-107d-40c8-b6c3-ce7546548044.png)

コメントをクリックした時
![スクリーンショット 2022-07-24 163319](https://user-images.githubusercontent.com/88410576/180648448-97560cfb-c871-426d-9d65-4f78d56f2c3d.png)

・・・を押したとき
![スクリーンショット 2022-07-24 163749](https://user-images.githubusercontent.com/88410576/180648455-65c7eb3a-f1e7-4cf9-861a-40397cad19d4.png)

・・・の「投稿の編集」を押したとき
![スクリーンショット 2022-07-24 221109](https://user-images.githubusercontent.com/88410576/180648538-a2bfc5d3-4eec-4ee1-abd7-7b26a0ee8bbc.png)

