### PR TITLE
スマホ用ヘッダー、フッターレイアウト修正

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { FC } from 'react'
+import { AiTwotoneHome, AiOutlineSearch, AiOutlineUser } from 'react-icons/ai'
+
+export const Footer: FC = () => {
+  return (
+    <footer className='sm:hidden'>
+      <button className='border rounded-full font-bold bg-red-500 border-red-500 text-white p-2 right-20px bottom-50px text-30px fixed'>
+        <Link href='/create'>＋</Link>
+      </button>
+
+      <nav className='bg-white flex w-full py-1.5 bottom-0 left-0 text-25px justify-around fixed'>
+        <Link href='/'>
+          <div>
+            <AiTwotoneHome className='cursor-pointer' />
+          </div>
+        </Link>
+        <Link href='/'>
+          {/* 記事検索 */}
+          <div>
+            <AiOutlineSearch className='cursor-pointer' />
+          </div>
+        </Link>
+        <Link href='/myPage'>
+          <div>
+            <AiOutlineUser className='cursor-pointer' />
+          </div>
+        </Link>
+      </nav>
+    </footer>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,15 +11,16 @@ export const Header: FC = () => {
 
   return (
     <>
-      <header className='bg-white w-full py-2 top-0 z-10000 fixed'>
+      <header className='bg-white w-full py-2 top-0 z-100 fixed'>
         <nav className='flex mx-4 items-center justify-between'>
           <Link href='/'>
-            <h1 className='cursor-pointer mt-0 mb-1  text-6xl text-red-500'>
+            <h1 className='cursor-pointer mt-0 mb-1  text-4xl text-red-500 sm:text-6xl'>
               SharePos
             </h1>
           </Link>
 
           <div className='flex gap-3 justify-end items-center'>
+            {/* <div className='gap-3 hidden justify-end items-center sm:flex'> */}
             <AiOutlineSearch className='cursor-pointer mt-1' />
             <div className='hidden'>
               <input
@@ -30,16 +31,18 @@ export const Header: FC = () => {
             {isLoggedIn ? (
               <div className='flex gap-3 justify-end items-center'>
                 <Link href='/create'>
-                  <div className='flex gap-0.5 items-center'>
-                    <div className='cursor-pointer duration-300 hover:(underline) '>
+                  <div className='cursor-pointer flex gap-0.5 items-center'>
+                    {/* <div className='duration-300 hover:(underline) '> */}
+                    <div className='duration-300 hidden sm:block hover:(underline) '>
                       投稿する
                     </div>
                     <BsPencilSquare />
                   </div>
                 </Link>
                 <Link href='/myPage'>
-                  <div className='flex gap-0.5 items-center'>
-                    <div className='cursor-pointer duration-300 hover:(underline) '>
+                  <div className='cursor-pointer flex gap-0.5 items-center'>
+                    {/* <div className='duration-300 hover:(underline) '> */}
+                    <div className='duration-300 hidden sm:block hover:(underline) '>
                       マイページ
                     </div>
                     <AiOutlineUser />
@@ -53,30 +56,6 @@ export const Header: FC = () => {
                 </div>
               </div>
             ) : (
-              // <div className='flex gap-2 justify-end items-center'>
-              //   <Link href='/create'>
-              //     <div className='text-center'>
-              //       <BsPencilSquare />
-              //       <div className='cursor-pointer duration-300 hover:(underline) '>
-              //         投稿する
-              //       </div>
-              //     </div>
-              //   </Link>
-              //   <Link href='/myPage'>
-              //     <div className='text-center'>
-              //       <AiOutlineUser />
-              //       <div className='cursor-pointer duration-300 hover:(underline) '>
-              //         マイページ
-              //       </div>
-              //     </div>
-              //   </Link>
-              //   <div
-              //     onClick={logOut}
-              //     className='cursor-pointer duration-300 hover:(underline) '
-              //   >
-              //     ログアウト
-              //   </div>
-              // </div>
               <div className='flex gap-2'>
                 <Link href='/login'>
                   <div className='cursor-pointer duration-300 hover:(underline) '>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,8 +9,10 @@ export const Layout: FC<Props> = ({ children }) => {
   return (
     <>
       <Header />
-      <main className='bg-red-100 min-h-100vh pt-130px overflow-hidden '>
-        <div className='mx-auto max-w-1110px px-2 break-words'>{children}</div>
+      <main className='bg-red-100 min-h-100vh  overflow-hidden '>
+        <div className='mx-auto mt-100px max-w-1110px px-2 break-words sm:mt-130px'>
+          {children}
+        </div>
       </main>
     </>
   )

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import { FC, ReactNode } from 'react'
+import { Footer } from './Footer'
 import { Header } from './Header'
 
 type Props = {
@@ -9,11 +10,13 @@ export const Layout: FC<Props> = ({ children }) => {
   return (
     <>
       <Header />
-      <main className='bg-red-100 min-h-100vh  overflow-hidden '>
+      <main className='bg-red-100 min-h-100vh overflow-hidden'>
         <div className='mx-auto mt-100px max-w-1110px px-2 break-words sm:mt-130px'>
           {children}
         </div>
       </main>
+
+      <Footer />
     </>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
 import { PostItemList } from 'components/post/PostItemList'
-import { PostStars } from 'components/post/PostStars'
 import { useAuthHeaderParams } from 'hooks/login/useAuth'
 import { useGetApi } from 'hooks/useApi'
 import { Post } from 'types/post'
@@ -24,10 +23,10 @@ const Home: NextPage = () => {
         <title>SharePos 投稿一覧ページ</title>
       </Head>
       <Layout>
-        <PostStars
+        {/* <PostStars
           evaluation={stars}
           onClick={(newStar) => setStars(newStar)}
-        />
+        /> */}
         {posts?.length && (
           <PostItemList className='flex flex-wrap mt-4 gap-3 justify-center'>
             {posts.map((post, i) => (


### PR DESCRIPTION
## 詳細
- スマホの時、ヘッダーをアイコンのみに
- スマホの時、フッターメニューを追加

## 動作確認

![スクリーンショット 2022-08-30 150500](https://user-images.githubusercontent.com/88410576/187369581-e3873699-872c-4ae0-90ae-ab87a8e2166e.png)
