### PR TITLE
Postのメニューの見た目・動き修正

### DIFF
--- a/src/components/bookmark/BookmarkFolderList.tsx
+++ b/src/components/bookmark/BookmarkFolderList.tsx
@@ -40,69 +40,67 @@ export const BookmarkFolderList: FC<Props> = ({
     <>
       {/* ブックマーク名一覧
           TODO: 掴め！！！！, 編集・削除をモーダルで */}
-      <div className='mt-5'>
-        <div className='h-50px overflow-x-scroll scroll-bar sm:(h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll) '>
-          <div className='flex gap-2 sm:(flex-col-reverse gap-1) '>
-            {folders.map((folder, index) => (
+      <div className='h-50px overflow-x-scroll scroll-bar sm:(h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll) '>
+        <div className='flex gap-2 sm:(flex-col-reverse gap-1) '>
+          {folders.map((folder, index) => (
+            <div
+              key={folder.id}
+              className={`whitespace-nowrap h-40px ${
+                selectedFolderIndex === index
+                  ? 'border-b-3 border-red-500 text-red-500'
+                  : 'text-gray-500 border-b-2'
+              }`}
+            >
               <div
-                key={folder.id}
-                className={`whitespace-nowrap h-40px ${
-                  selectedFolderIndex === index
-                    ? 'border-b-3 border-red-500 text-red-500'
-                    : 'text-gray-500 border-b-2'
+                className={`flex items-center mt-2 ${
+                  selectedFolderIndex === index && 'font-bold'
                 }`}
               >
-                <div
-                  className={`flex items-center mt-2 ${
-                    selectedFolderIndex === index && 'font-bold'
-                  }`}
-                >
-                  {/* {folder.name} */}
-                  {editingFolderIndex === index ? (
-                    <form
-                      className='flex'
-                      onSubmit={async (e) => {
+                {/* {folder.name} */}
+                {editingFolderIndex === index ? (
+                  <form
+                    className='flex'
+                    onSubmit={async (e) => {
+                      setEditingFolderIndex(undefined)
+                      e.preventDefault()
+                      await updateFolder(folder.id, editFolderName)
+                    }}
+                  >
+                    <input
+                      type='text'
+                      className='border outline-none text-black ring-blue-500 w-100px duration-300 focus:rounded-10px focus:ring-1'
+                      maxLength={15}
+                      value={editFolderName}
+                      onChange={(e) => setEditFolderName(e.target.value)}
+                    />
+                    <button
+                      className='font-bold bg-blue-500 text-white py-0.5 px-1'
+                      type='submit'
+                    >
+                      更新
+                    </button>
+                    <div
+                      className='cursor-pointer font-bold bg-red-500 text-white ml-1 py-0.5 px-1'
+                      onClick={async () => {
                         setEditingFolderIndex(undefined)
-                        e.preventDefault()
-                        await updateFolder(folder.id, editFolderName)
+                        await deleteFolder(folder.id)
                       }}
                     >
-                      <input
-                        type='text'
-                        className='border outline-none text-black ring-blue-500 w-100px duration-300 focus:rounded-10px focus:ring-1'
-                        maxLength={15}
-                        value={editFolderName}
-                        onChange={(e) => setEditFolderName(e.target.value)}
-                      />
-                      <button
-                        className='font-bold bg-blue-500 text-white py-0.5 px-1'
-                        type='submit'
-                      >
-                        更新
-                      </button>
-                      <div
-                        className='cursor-pointer font-bold bg-red-500 text-white ml-1 py-0.5 px-1'
-                        onClick={async () => {
-                          setEditingFolderIndex(undefined)
-                          await deleteFolder(folder.id)
-                        }}
-                      >
-                        削除
-                      </div>
-                    </form>
-                  ) : (
-                    <button
-                      className='text-left w-full'
-                      onClick={() => onClickFolder(index, folder.name)}
-                    >
-                      <BsFolderIcon className='mr-1' />
-                      {folder.name}
-                    </button>
-                  )}
-                </div>
+                      削除
+                    </div>
+                  </form>
+                ) : (
+                  <button
+                    className='text-left w-full'
+                    onClick={() => onClickFolder(index, folder.name)}
+                  >
+                    <BsFolderIcon className='mr-1' />
+                    {folder.name}
+                  </button>
+                )}
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/src/components/bookmark/BookmarkFolderList.tsx
+++ b/src/components/bookmark/BookmarkFolderList.tsx
@@ -38,12 +38,11 @@ export const BookmarkFolderList: FC<Props> = ({
 
   return (
     <>
-      {/* // ブックマーク名一覧
-        // TODO: 掴め！！！！, 編集・削除をモーダルで
-        // <div className='flex h-50px mt-5 gap-2 overflow-x-scroll scroll-bar sm:(flex-col h-auto min-w-20 ) '> */}
+      {/* ブックマーク名一覧
+          TODO: 掴め！！！！, 編集・削除をモーダルで */}
       <div className='mt-5'>
         <div className='h-50px overflow-x-scroll scroll-bar sm:(h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll) '>
-          <div className='flex gap-2 sm:(flex-col gap-1) '>
+          <div className='flex gap-2 sm:(flex-col-reverse gap-1) '>
             {folders.map((folder, index) => (
               <div
                 key={folder.id}

--- a/src/components/post/Item/FolderList.tsx
+++ b/src/components/post/Item/FolderList.tsx
@@ -18,7 +18,7 @@ export const FolderList: FC<Props> = ({ post, onClickFolderName }) => {
   const { addBookmark } = useAddBookmark()
 
   const authHeaderParams = useAuthHeaderParams()
-  const { data: folders, mutate } = useGetApi<Folder[]>(
+  const { data: folders } = useGetApi<Folder[]>(
     '/folders',
     undefined,
     authHeaderParams,
@@ -39,19 +39,19 @@ export const FolderList: FC<Props> = ({ post, onClickFolderName }) => {
           display: none;
         }
       `}</style>
-      <div className='border bg-red-100 border-red-500 rounded-10px w-145px'>
+      <div className='border bg-red-100 border-red-500 rounded-10px w-160px'>
         {/* <div
           onClick={() => setIsOpenModal(true)}
           className='rounded-t-10px px-2 pt-2 hover:bg-red-300'
         >
           ブックマークを作成+ モーダル出す
         </div> */}
-        <div className='max-h-180px overflow-y-scroll scroll-bar-none sm:max-h-303px'>
+        <div className='max-h-250px overflow-y-scroll scroll-bar-none sm:max-h-450px'>
           {folders?.length &&
             folders.map((folder) => (
               <div
                 key={folder.id}
-                className='flex px-2 gap-1 items-center hover:bg-red-300'
+                className='flex py-1 px-4 gap-1 items-center hover:bg-red-300'
               >
                 <BsFolderIcon />
                 <div

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -53,7 +53,6 @@ export const PostMenuButton: FC<Props> = ({
 
           <div className='top-[-35px] right-5px z-11 absolute sm:top-[-35px] '>
             <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform shadow-red-200 w-170px sm:w-150px'>
-              {/* <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform top-[-35px] right-[-27px] shadow-red-200 w-170px z-11 absolute sm:top-[-30px] sm:right-5px sm:w-150px'> */}
               {cookies.userInfo?.id === post.userId && (
                 <>
                   <div
@@ -104,10 +103,9 @@ export const PostMenuButton: FC<Props> = ({
                   {/* 自分のフォルダ一覧  */}
                   <div
                     className={`${
-                      isOpenFolder ? '' : 'hidden'
+                      !isOpenFolder && 'hidden'
                     } sm:group-hover:block`}
                   >
-                    {/* <div className='top-0px right-150px absolute sm:right-80px'> */}
                     <div className='shadow-md top-0px right-80px shadow-red-200 absolute sm:right-80px'>
                       <FolderList post={post} onClickFolderName={closeMenu} />
                     </div>

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useCallback, useState } from 'react'
 
 import { BsThreeDots as BsThreeDotsIcon } from 'react-icons/bs'
 
@@ -26,6 +26,12 @@ export const PostMenuButton: FC<Props> = ({
   const { cookies } = useCookies('userInfo')
   const { deletePost } = useDeletePost(post)
   const [isOpenMenu, setIsOpenMenu] = useState(false)
+  const [isOpenFolder, setIsOpenFolder] = useState(false)
+
+  const closeMenu = useCallback(() => {
+    setIsOpenMenu(false)
+    setIsOpenFolder(false)
+  }, [])
 
   return (
     <div>
@@ -41,7 +47,7 @@ export const PostMenuButton: FC<Props> = ({
         <div className='h-0 w-0 relative'>
           {/* モーダルの周り押したら消えるやつ */}
           <div
-            onClick={() => setIsOpenMenu(false)}
+            onClick={closeMenu}
             className='h-100vh top-0 left-0 w-100vw z-10 fixed'
           ></div>
           <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform top-[-35px] right-[-27px] shadow-red-200 w-170px z-11 absolute sm:top-[-30px] sm:right-5px sm:w-150px'>
@@ -59,7 +65,7 @@ export const PostMenuButton: FC<Props> = ({
                 <div
                   className='py-1 px-4 hover:bg-red-300'
                   onClick={async () => {
-                    setIsOpenMenu(false)
+                    closeMenu()
                     await deletePost()
                   }}
                 >
@@ -76,23 +82,29 @@ export const PostMenuButton: FC<Props> = ({
               onClick={() => {
                 navigator.clipboard.writeText(post.url)
                 alert('リンクをコピーしました')
-                setIsOpenMenu(false)
+                closeMenu()
               }}
             >
               記事リンクをコピー
             </div>
             {cookies.userInfo && (
               <div className='rounded-b-10px group relative'>
-                <div className='px-4 pt-1 pb-2 hover:bg-red-300'>
+                <div
+                  className='px-4 pt-1 pb-2 hover:bg-red-300'
+                  onClick={() => setIsOpenFolder(!isOpenFolder)}
+                >
                   ブックマークに追加
                 </div>
 
                 {/* 自分のフォルダ一覧  */}
-                <div className='top-0px right-150px hidden absolute sm:right-80px group-hover:block'>
-                  <FolderList
-                    post={post}
-                    onClickFolderName={() => setIsOpenMenu(false)}
-                  />
+                <div
+                  className={`${
+                    isOpenFolder ? '' : 'hidden'
+                  } sm:group-hover:block`}
+                >
+                  <div className='top-0px right-150px absolute sm:right-80px'>
+                    <FolderList post={post} onClickFolderName={closeMenu} />
+                  </div>
                 </div>
               </div>
             )}

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -107,7 +107,8 @@ export const PostMenuButton: FC<Props> = ({
                       isOpenFolder ? '' : 'hidden'
                     } sm:group-hover:block`}
                   >
-                    <div className='top-0px right-150px absolute sm:right-80px'>
+                    {/* <div className='top-0px right-150px absolute sm:right-80px'> */}
+                    <div className='shadow-md top-0px right-80px shadow-red-200 absolute sm:right-80px'>
                       <FolderList post={post} onClickFolderName={closeMenu} />
                     </div>
                   </div>

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -50,64 +50,70 @@ export const PostMenuButton: FC<Props> = ({
             onClick={closeMenu}
             className='h-100vh top-0 left-0 w-100vw z-10 fixed'
           ></div>
-          <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform top-[-35px] right-[-27px] shadow-red-200 w-170px z-11 absolute sm:top-[-30px] sm:right-5px sm:w-150px'>
-            {cookies.userInfo?.id === post.userId && (
-              <>
-                <div
-                  className='rounded-t-10px px-4 pt-2 pb-1 hover:bg-red-300'
-                  onClick={() => {
-                    onEdit?.()
-                    setIsOpenMenu(false)
-                  }}
-                >
-                  投稿を編集する
-                </div>
-                <div
-                  className='py-1 px-4 hover:bg-red-300'
-                  onClick={async () => {
-                    closeMenu()
-                    await deletePost()
-                  }}
-                >
-                  投稿を
-                  <span className='font-bold text-red-500 text-18px'>削除</span>
-                  する
-                </div>
-              </>
-            )}
-            <div
-              className={`py-1 px-4 hover:bg-red-300 ${
-                cookies.userInfo?.id !== post.userId && 'pt-2 rounded-t-10px'
-              }`}
-              onClick={() => {
-                navigator.clipboard.writeText(post.url)
-                alert('リンクをコピーしました')
-                closeMenu()
-              }}
-            >
-              記事リンクをコピー
-            </div>
-            {cookies.userInfo && (
-              <div className='rounded-b-10px group relative'>
-                <div
-                  className='px-4 pt-1 pb-2 hover:bg-red-300'
-                  onClick={() => setIsOpenFolder(!isOpenFolder)}
-                >
-                  ブックマークに追加
-                </div>
 
-                {/* 自分のフォルダ一覧  */}
-                <div
-                  className={`${
-                    isOpenFolder ? '' : 'hidden'
-                  } sm:group-hover:block`}
-                >
-                  <div className='top-0px right-150px absolute sm:right-80px'>
-                    <FolderList post={post} onClickFolderName={closeMenu} />
+          <div className='top-[-35px] right-5px z-11 absolute sm:top-[-35px] '>
+            <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform shadow-red-200 w-170px sm:w-150px'>
+              {/* <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform top-[-35px] right-[-27px] shadow-red-200 w-170px z-11 absolute sm:top-[-30px] sm:right-5px sm:w-150px'> */}
+              {cookies.userInfo?.id === post.userId && (
+                <>
+                  <div
+                    className='rounded-t-10px px-4 pt-2 pb-1 hover:bg-red-300'
+                    onClick={() => {
+                      onEdit?.()
+                      setIsOpenMenu(false)
+                    }}
+                  >
+                    投稿を編集する
+                  </div>
+                  <div
+                    className='py-1 px-4 hover:bg-red-300'
+                    onClick={async () => {
+                      closeMenu()
+                      await deletePost()
+                    }}
+                  >
+                    投稿を
+                    <span className='font-bold text-red-500 text-18px'>
+                      削除
+                    </span>
+                    する
+                  </div>
+                </>
+              )}
+              <div
+                className={`py-1 px-4 hover:bg-red-300 ${
+                  cookies.userInfo?.id !== post.userId && 'pt-2 rounded-t-10px'
+                }`}
+                onClick={() => {
+                  navigator.clipboard.writeText(post.url)
+                  alert('リンクをコピーしました')
+                  closeMenu()
+                }}
+              >
+                記事リンクをコピー
+              </div>
+              {cookies.userInfo && (
+                <div className='rounded-b-10px group relative'>
+                  <div
+                    className='px-4 pt-1 pb-2 hover:bg-red-300'
+                    onClick={() => setIsOpenFolder(!isOpenFolder)}
+                  >
+                    ブックマークに追加
+                  </div>
+
+                  {/* 自分のフォルダ一覧  */}
+                  <div
+                    className={`${
+                      isOpenFolder ? '' : 'hidden'
+                    } sm:group-hover:block`}
+                  >
+                    <div className='top-0px right-150px absolute sm:right-80px'>
+                      <FolderList post={post} onClickFolderName={closeMenu} />
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -42,7 +42,8 @@ const Bookmark: NextPage = () => {
           <div className='sm:(flex gap-3 items-start) '>
             {/* 自分のフォルダ一覧 */}
             {folders && (
-              <div className='ml-4 top-100px sm:sticky'>
+              <div className='bg-red-100 pl-4 top-60px z-10 sticky sm:top-100px'>
+                {/* <div className='ml-4 top-100px sm:sticky'> */}
                 <BookmarkFolderList
                   folders={folders}
                   selectedFolderIndex={selectedFolderIndex}
@@ -58,7 +59,7 @@ const Bookmark: NextPage = () => {
               // <div className='flex flex-wrap mt-4 justify-center items-start sm:justify-start'>
               <div className='mt-4 w-full'>
                 {/* TODO: スマホサイズのレイアウト修正 */}
-                <div className='grid gap-3 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
+                <div className='grid gap-6 justify-center items-start sm:(gap-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
                   {bookmarkPosts.posts.map((post, i) => (
                     <PostItem
                       key={i}

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -46,11 +46,13 @@ const Bookmark: NextPage = () => {
                 <div className='mt-4 w-190px hidden sm:block'>
                   <CreateFolderField />
                 </div>
-                <BookmarkFolderList
-                  folders={folders}
-                  selectedFolderIndex={selectedFolderIndex}
-                  onSelect={setSelectedFolderIndex}
-                />
+                <div className='mt-5'>
+                  <BookmarkFolderList
+                    folders={folders}
+                    selectedFolderIndex={selectedFolderIndex}
+                    onSelect={setSelectedFolderIndex}
+                  />
+                </div>
               </div>
             )}
             {/* 選択しているフォルダの記事一覧 */}

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -43,15 +43,14 @@ const Bookmark: NextPage = () => {
             {/* 自分のフォルダ一覧 */}
             {folders && (
               <div className='bg-red-100 pl-4 top-60px z-10 sticky sm:top-100px'>
-                {/* <div className='ml-4 top-100px sm:sticky'> */}
+                <div className='mt-4 w-190px hidden sm:block'>
+                  <CreateFolderField />
+                </div>
                 <BookmarkFolderList
                   folders={folders}
                   selectedFolderIndex={selectedFolderIndex}
                   onSelect={setSelectedFolderIndex}
                 />
-                <div className='mt-4 w-190px hidden sm:block'>
-                  <CreateFolderField />
-                </div>
               </div>
             )}
             {/* 選択しているフォルダの記事一覧 */}
@@ -59,7 +58,7 @@ const Bookmark: NextPage = () => {
               // <div className='flex flex-wrap mt-4 justify-center items-start sm:justify-start'>
               <div className='mt-4 w-full'>
                 {/* TODO: スマホサイズのレイアウト修正 */}
-                <div className='grid gap-6 justify-center items-start sm:(gap-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
+                <div className='grid gap-6 justify-center items-start sm:(gap-x-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
                   {bookmarkPosts.posts.map((post, i) => (
                     <PostItem
                       key={i}

--- a/src/pages/myPage.tsx
+++ b/src/pages/myPage.tsx
@@ -51,25 +51,27 @@ const MyPage: NextPage = () => {
         </ul>
       </section>
 
-      <section className='mt-10 ml-4'>
-        <h1 className='font-bold text-2xl'>投稿した記事</h1>
-        <div className='border-b flex border-gray-300 h-30px mt-5 w-full gap-3'>
-          {[
-            { label: '公開している投稿', published: true },
-            { label: '非公開の投稿', published: false },
-          ].map((tab, i) => (
-            <button
-              key={i}
-              onClick={() => setSelectedPublished(tab.published)}
-              className={`${
-                selectedPublished === tab.published
-                  ? 'font-bold border-b-2 border-red-500 text-red-500'
-                  : ' cursor-pointer'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+      <section className='mt-10'>
+        <div className='ml-4'>
+          <h1 className='font-bold text-2xl'>投稿した記事</h1>
+          <div className='border-b flex border-gray-300 h-30px mt-5 w-full gap-3'>
+            {[
+              { label: '公開している投稿', published: true },
+              { label: '非公開の投稿', published: false },
+            ].map((tab, i) => (
+              <button
+                key={i}
+                onClick={() => setSelectedPublished(tab.published)}
+                className={`${
+                  selectedPublished === tab.published
+                    ? 'font-bold border-b-2 border-red-500 text-red-500'
+                    : ' cursor-pointer'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
         </div>
 
         {myPosts?.posts.length && (

--- a/src/pages/myPage.tsx
+++ b/src/pages/myPage.tsx
@@ -6,6 +6,7 @@ import { AiOutlineUser as AiOutlineUserIcon } from 'react-icons/ai'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
 import { useAuthHeaderParams } from 'hooks/login/useAuth'
+import { useRequireLogin } from 'hooks/login/useRequireLogin'
 import { useGetApi } from 'hooks/useApi'
 import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
@@ -19,6 +20,7 @@ type MyPosts = {
 }
 
 const MyPage: NextPage = () => {
+  useRequireLogin()
   const [selectedPublished, setSelectedPublished] = useState(true)
   const { cookies } = useCookies('userInfo')
   const authHeaderParams = useAuthHeaderParams()


### PR DESCRIPTION
## 詳細
- スマホの時のメニュー・フォルダ追加の位置を修正
- フォルダ追加の高さを上げる
- フォルダの表示の仕方変更
  - PC
    - group-hoverで、フォルダを表示
    - `ブックマークに追加`をクリックでも、フォルダを表示
  - スマホ
    -  `ブックマークに追加 `  をクリックで、フォルダを表示

## 動作確認

PC
![スクリーンショット 2022-09-13 141147](https://user-images.githubusercontent.com/88410576/189814570-8ed3e12b-cf2e-4374-b169-22da28db2ccc.png)

スマホ

ホバーしてもフォルダを表示しない
![スクリーンショット 2022-09-13 141632](https://user-images.githubusercontent.com/88410576/189815002-79c12d54-cad7-44b3-b770-5f25e5720ffd.png)

`ブックマークに追加`をクリックで、stateを変化させてフォルダを表示
![image](https://user-images.githubusercontent.com/88410576/189814529-862cfc1e-5453-40ca-9029-b5c4654405ec.png)

### 再度修正

スマホの時、フォルダ一覧が追従

![スクリーンショット 2022-09-14 162225](https://user-images.githubusercontent.com/88410576/190088108-1ea1ed8f-f130-42a2-9fc0-8b7aceafc18a.png)


パソコンの時、フォルダが昇順で並び、新規作成を上に表示
ブックマークページのPostItemの間隔を、gap-x-3 gap-y-6に

![スクリーンショット 2022-09-14 162201](https://user-images.githubusercontent.com/88410576/190088089-6eb45b0e-976b-4da3-9541-51526fbf7292.png)

