### PR TITLE
Feature/change auth cookie auth easily

### DIFF
--- a/src/components/post/Item/FolderList.tsx
+++ b/src/components/post/Item/FolderList.tsx
@@ -16,7 +16,7 @@ export const FolderList: FC<Props> = ({ post, onClickFolderName }) => {
   const [isOpenModal, setIsOpenModal] = useState(false)
   const { addBookmark } = useAddBookmark()
 
-  const { data: folders } = useGetApi<Folder[]>('/folders', undefined)
+  const { data: folders } = useGetApi<Folder[]>('/folders')
 
   return (
     <div>

--- a/src/components/post/Item/FolderList.tsx
+++ b/src/components/post/Item/FolderList.tsx
@@ -2,7 +2,6 @@ import { FC, useState } from 'react'
 
 import { BsFolder as BsFolderIcon } from 'react-icons/bs'
 
-import { useAuthHeaderParams } from 'hooks/login/useAuth'
 import { useGetApi } from 'hooks/useApi'
 import { useAddBookmark } from 'hooks/useBookmark'
 import { Folder } from 'types/bookmark'
@@ -17,12 +16,7 @@ export const FolderList: FC<Props> = ({ post, onClickFolderName }) => {
   const [isOpenModal, setIsOpenModal] = useState(false)
   const { addBookmark } = useAddBookmark()
 
-  const authHeaderParams = useAuthHeaderParams()
-  const { data: folders } = useGetApi<Folder[]>(
-    '/folders',
-    undefined,
-    authHeaderParams,
-  )
+  const { data: folders } = useGetApi<Folder[]>('/folders', undefined)
 
   return (
     <div>

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -3,9 +3,10 @@ import { FC, useCallback, useState } from 'react'
 import { BsThreeDots as BsThreeDotsIcon } from 'react-icons/bs'
 
 import { FolderList } from './FolderList'
+import { useGetApi } from 'hooks/useApi'
 import { useDeletePost } from 'hooks/usePost'
-import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
+import { User } from 'types/user/user'
 
 type MenuProps = {
   onEdit?: () => void
@@ -23,7 +24,7 @@ export const PostMenuButton: FC<Props> = ({
   onDelete,
   onAddBookmark,
 }) => {
-  const { cookies } = useCookies('user_info')
+  const { data: user } = useGetApi<User>('/users/me')
   const { deletePost } = useDeletePost(post)
   const [isOpenMenu, setIsOpenMenu] = useState(false)
   const [isOpenFolder, setIsOpenFolder] = useState(false)
@@ -53,7 +54,7 @@ export const PostMenuButton: FC<Props> = ({
 
           <div className='top-[-35px] right-5px z-2 absolute sm:top-[-35px] '>
             <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform shadow-red-200 w-170px sm:w-150px'>
-              {cookies.user_info?.id === post.userId && (
+              {user?.id === post.userId && (
                 <>
                   <div
                     className='rounded-t-10px px-4 pt-2 pb-1 hover:bg-red-300'
@@ -81,7 +82,7 @@ export const PostMenuButton: FC<Props> = ({
               )}
               <div
                 className={`py-1 px-4 hover:bg-red-300 ${
-                  cookies.user_info?.id !== post.userId && 'pt-2 rounded-t-10px'
+                  user?.id !== post.userId && 'pt-2 rounded-t-10px'
                 }`}
                 onClick={() => {
                   navigator.clipboard.writeText(post.url)
@@ -91,7 +92,7 @@ export const PostMenuButton: FC<Props> = ({
               >
                 記事リンクをコピー
               </div>
-              {cookies.user_info && (
+              {user && (
                 <div className='rounded-b-10px group relative'>
                   <div
                     className='px-4 pt-1 pb-2 hover:bg-red-300'

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -23,7 +23,7 @@ export const PostMenuButton: FC<Props> = ({
   onDelete,
   onAddBookmark,
 }) => {
-  const { cookies } = useCookies('userInfo')
+  const { cookies } = useCookies('user_info')
   const { deletePost } = useDeletePost(post)
   const [isOpenMenu, setIsOpenMenu] = useState(false)
   const [isOpenFolder, setIsOpenFolder] = useState(false)
@@ -53,7 +53,7 @@ export const PostMenuButton: FC<Props> = ({
 
           <div className='top-[-35px] right-5px z-2 absolute sm:top-[-35px] '>
             <div className='border cursor-pointer bg-red-100 border-red-600 rounded-10px shadow-lg transform shadow-red-200 w-170px sm:w-150px'>
-              {cookies.userInfo?.id === post.userId && (
+              {cookies.user_info?.id === post.userId && (
                 <>
                   <div
                     className='rounded-t-10px px-4 pt-2 pb-1 hover:bg-red-300'
@@ -81,7 +81,7 @@ export const PostMenuButton: FC<Props> = ({
               )}
               <div
                 className={`py-1 px-4 hover:bg-red-300 ${
-                  cookies.userInfo?.id !== post.userId && 'pt-2 rounded-t-10px'
+                  cookies.user_info?.id !== post.userId && 'pt-2 rounded-t-10px'
                 }`}
                 onClick={() => {
                   navigator.clipboard.writeText(post.url)
@@ -91,7 +91,7 @@ export const PostMenuButton: FC<Props> = ({
               >
                 記事リンクをコピー
               </div>
-              {cookies.userInfo && (
+              {cookies.user_info && (
                 <div className='rounded-b-10px group relative'>
                   <div
                     className='px-4 pt-1 pb-2 hover:bg-red-300'

--- a/src/hooks/login/useAuth.ts
+++ b/src/hooks/login/useAuth.ts
@@ -6,7 +6,7 @@ import { User } from 'types/user/user'
 import { deleteApi, HttpError, postApi } from 'utils/api'
 
 export const useLogin = () => {
-  const { set } = useCookies(['token', 'userInfo'])
+  const { set } = useCookies(['token', 'user_info'])
   const router = useRouter()
 
   const login = useCallback(
@@ -18,7 +18,7 @@ export const useLogin = () => {
         }
 
         // set('token', res.token)
-        // set('userInfo', { id: res.id, username: res.username })
+        // set('user_info', { id: res.id, username: res.username })
         console.log('ログインに成功しました', res)
         router.push('/')
       } catch (e) {
@@ -33,7 +33,7 @@ export const useLogin = () => {
 }
 
 export const useSignUp = () => {
-  const { set } = useCookies(['token', 'userInfo'])
+  const { set } = useCookies(['token', 'user_info'])
   const router = useRouter()
 
   const signUp = useCallback(
@@ -47,7 +47,7 @@ export const useSignUp = () => {
         console.log('ユーザー作成に成功しました', res)
 
         // set('token', res.token)
-        // set('userInfo', { id: res.id, username: res.username })
+        // set('user_info', { id: res.id, username: res.username })
         router.push('/')
       } catch (e) {
         if (e instanceof HttpError) {

--- a/src/hooks/login/useAuth.ts
+++ b/src/hooks/login/useAuth.ts
@@ -1,12 +1,10 @@
 import { useRouter } from 'next/router'
 import { useCallback } from 'react'
-import { useCookies } from 'stores/useCookies'
 import { LoginRequestParams, SignUpRequestParams } from 'types/user/auth'
 import { User } from 'types/user/user'
 import { deleteApi, HttpError, postApi } from 'utils/api'
 
 export const useLogin = () => {
-  const { set } = useCookies(['token', 'user_info'])
   const router = useRouter()
 
   const login = useCallback(
@@ -17,8 +15,6 @@ export const useLogin = () => {
           return
         }
 
-        // set('token', res.token)
-        // set('user_info', { id: res.id, username: res.username })
         console.log('ログインに成功しました', res)
         router.push('/')
       } catch (e) {
@@ -33,7 +29,6 @@ export const useLogin = () => {
 }
 
 export const useSignUp = () => {
-  const { set } = useCookies(['token', 'user_info'])
   const router = useRouter()
 
   const signUp = useCallback(
@@ -44,10 +39,8 @@ export const useSignUp = () => {
         if (!res) {
           return
         }
-        console.log('ユーザー作成に成功しました', res)
 
-        // set('token', res.token)
-        // set('user_info', { id: res.id, username: res.username })
+        console.log('ユーザー作成に成功しました', res)
         router.push('/')
       } catch (e) {
         if (e instanceof HttpError) {

--- a/src/hooks/login/useAuth.ts
+++ b/src/hooks/login/useAuth.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { useCookies } from 'stores/useCookies'
 import { LoginRequestParams, SignUpRequestParams } from 'types/user/auth'
 import { User } from 'types/user/user'
-import { HttpError, postApi } from 'utils/api'
+import { deleteApi, HttpError, postApi } from 'utils/api'
 
 export const useLogin = () => {
   const { set } = useCookies(['token', 'userInfo'])
@@ -17,8 +17,8 @@ export const useLogin = () => {
           return
         }
 
-        set('token', res.token)
-        set('userInfo', { id: res.id, username: res.username })
+        // set('token', res.token)
+        // set('userInfo', { id: res.id, username: res.username })
         console.log('ログインに成功しました', res)
         router.push('/')
       } catch (e) {
@@ -27,7 +27,7 @@ export const useLogin = () => {
         }
       }
     },
-    [router, set],
+    [router],
   )
   return { login }
 }
@@ -46,8 +46,8 @@ export const useSignUp = () => {
         }
         console.log('ユーザー作成に成功しました', res)
 
-        set('token', res.token)
-        set('userInfo', { id: res.id, username: res.username })
+        // set('token', res.token)
+        // set('userInfo', { id: res.id, username: res.username })
         router.push('/')
       } catch (e) {
         if (e instanceof HttpError) {
@@ -55,23 +55,28 @@ export const useSignUp = () => {
         }
       }
     },
-    [router, set],
+    [router],
   )
   return { signUp }
 }
 
 export const useLogOut = () => {
-  const { remove } = useCookies(['token', 'userInfo'])
   const router = useRouter()
+  const logout = useCallback(async () => {
+    try {
+      const res = await deleteApi('/auth/logout')
+      console.log('ログアウトしました')
+    } catch (e) {
+      if (e instanceof HttpError) {
+        console.log(e)
+      }
+    }
+  }, [])
+
   return {
     logOut: () => {
-      remove(['token', 'userInfo'])
+      logout()
       router.push('/')
     },
   }
-}
-
-export const useAuthHeaderParams = () => {
-  const { cookies } = useCookies('token')
-  return { Authorization: `Token ${cookies.token}` }
 }

--- a/src/hooks/login/useIsLoggedIn.ts
+++ b/src/hooks/login/useIsLoggedIn.ts
@@ -1,32 +1,39 @@
-// import { useRouter } from 'next/router'
-import { useEffect } from 'react'
-// import { useLogOut } from './useAuth'
-import { useCookies } from 'stores/useCookies'
-import { useGlobalState } from 'stores/useGlobalState'
+import { useGetApi } from 'hooks/useApi'
 
-// export const useObserveAuthInfoExpired = () => {
-//   const { cookies } = useCookies('authInfo')
-//   const { logOut } = useLogOut()
-//   const router = useRouter()
+// user_idがCookieにあるとログイン。でも、そのまま確認できない。
+// /users/me にアクセスしてresがあるなら、ログイン
+// resからuser_info{user_id,username}をCookieに格納
+export const useIsLoggedIn = (): boolean => {
+  const { data, error } = useGetApi('/users/me')
+  console.log(data)
+  // const { cookies } = useCookies('token')
+  // const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
+
+  // useEffect(() => {
+  //   if (cookies.token) {
+  //     setIsLoggedIn(true)
+  //   } else {
+  //     setIsLoggedIn(false)
+  //   }
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [cookies.token])
+  if (error) {
+    return false
+  }
+  return data ?? true
+}
+
+// export const useIsLoggedIn = (): boolean => {
+//   const { cookies } = useCookies('token')
+//   const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
 
 //   useEffect(() => {
-//     if (Number(cookies?.authInfo?.expiry) < Date.now() / 1000) {
-//       logOut()
+//     if (cookies.token) {
+//       setIsLoggedIn(true)
+//     } else {
+//       setIsLoggedIn(false)
 //     }
-//   }, [cookies?.authInfo?.expiry, logOut, router.pathname])
+//     // eslint-disable-next-line react-hooks/exhaustive-deps
+//   }, [cookies.token])
+//   return isLoggedIn ?? true
 // }
-
-export const useIsLoggedIn = (): boolean => {
-  const { cookies } = useCookies('token')
-  const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
-
-  useEffect(() => {
-    if (cookies.token) {
-      setIsLoggedIn(true)
-    } else {
-      setIsLoggedIn(false)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cookies.token])
-  return isLoggedIn ?? true
-}

--- a/src/hooks/login/useIsLoggedIn.ts
+++ b/src/hooks/login/useIsLoggedIn.ts
@@ -1,26 +1,31 @@
-import { useGetApi } from 'hooks/useApi'
+// import { useGetApi } from 'hooks/useApi'
+import { useEffect } from 'react'
+import { useCookies } from 'stores/useCookies'
+import { useGlobalState } from 'stores/useGlobalState'
 
 // user_idがCookieにあるとログイン。でも、そのまま確認できない。
 // /users/me にアクセスしてresがあるなら、ログイン
 // resからuser_info{user_id,username}をCookieに格納
 export const useIsLoggedIn = (): boolean => {
-  const { data, error } = useGetApi('/users/me')
-  console.log(data)
-  // const { cookies } = useCookies('token')
-  // const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
+  const { cookies } = useCookies('user_info')
+  const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
 
-  // useEffect(() => {
-  //   if (cookies.token) {
-  //     setIsLoggedIn(true)
-  //   } else {
-  //     setIsLoggedIn(false)
-  //   }
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [cookies.token])
-  if (error) {
-    return false
-  }
-  return data ?? true
+  useEffect(() => {
+    if (cookies.user_info) {
+      setIsLoggedIn(true)
+    } else {
+      setIsLoggedIn(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cookies.user_info])
+  return isLoggedIn ?? true
+
+  // グローバルステートで管理
+  // const { data, error } = useGetApi('/users/me')
+  // if (error) {
+  //   return false
+  // }
+  // return data ?? true
 }
 
 // export const useIsLoggedIn = (): boolean => {

--- a/src/hooks/login/useIsLoggedIn.ts
+++ b/src/hooks/login/useIsLoggedIn.ts
@@ -1,44 +1,7 @@
-// import { useGetApi } from 'hooks/useApi'
-import { useEffect } from 'react'
-import { useCookies } from 'stores/useCookies'
-import { useGlobalState } from 'stores/useGlobalState'
+import { useGetApi } from 'hooks/useApi'
 
-// user_idがCookieにあるとログイン。でも、そのまま確認できない。
-// /users/me にアクセスしてresがあるなら、ログイン
-// resからuser_info{user_id,username}をCookieに格納
 export const useIsLoggedIn = (): boolean => {
-  const { cookies } = useCookies('user_info')
-  const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
-
-  useEffect(() => {
-    if (cookies.user_info) {
-      setIsLoggedIn(true)
-    } else {
-      setIsLoggedIn(false)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cookies.user_info])
-  return isLoggedIn ?? true
-
-  // グローバルステートで管理
-  // const { data, error } = useGetApi('/users/me')
-  // if (error) {
-  //   return false
-  // }
-  // return data ?? true
+  const { error } = useGetApi('/users/me')
+  if (error) return false
+  return true
 }
-
-// export const useIsLoggedIn = (): boolean => {
-//   const { cookies } = useCookies('token')
-//   const [isLoggedIn, setIsLoggedIn] = useGlobalState('isLoggedIn')
-
-//   useEffect(() => {
-//     if (cookies.token) {
-//       setIsLoggedIn(true)
-//     } else {
-//       setIsLoggedIn(false)
-//     }
-//     // eslint-disable-next-line react-hooks/exhaustive-deps
-//   }, [cookies.token])
-//   return isLoggedIn ?? true
-// }

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -8,8 +8,8 @@ export const useAddBookmark = () => {
   const addBookmark = useCallback(async (folderId: number, post: Post) => {
     try {
       const res = await postApi('/folders/bookmarks', {
-        folder_id: folderId,
-        post_id: post.id,
+        folderId,
+        postId: post.id,
       })
       console.log(res)
     } catch (e) {

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -25,7 +25,6 @@ export const useAddBookmark = () => {
 export const useRemoveBookmark = (selectedFolder: number, post: Post) => {
   const { data: bookmarkPosts, mutate: postsMutate } = useGetApi<BookmarkPosts>(
     `/folders/${selectedFolder}`,
-    undefined,
   )
 
   const removeBookmark = useCallback(async () => {

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -1,50 +1,36 @@
 import { useCallback } from 'react'
-import { useAuthHeaderParams } from './login/useAuth'
 import { useGetApi } from './useApi'
 import { BookmarkPosts } from 'types/bookmark'
 import { Post } from 'types/post'
 import { postApi, HttpError, deleteApi } from 'utils/api'
 
 export const useAddBookmark = () => {
-  const authHeaderParams = useAuthHeaderParams()
-
-  const addBookmark = useCallback(
-    async (folderId: number, post: Post) => {
-      try {
-        const res = await postApi(
-          '/folders/bookmarks',
-          { folder_id: folderId, post_id: post.id },
-          authHeaderParams,
-        )
-        console.log(res)
-      } catch (e) {
-        if (e instanceof HttpError) {
-          console.error(e.message)
-        }
+  const addBookmark = useCallback(async (folderId: number, post: Post) => {
+    try {
+      const res = await postApi('/folders/bookmarks', {
+        folder_id: folderId,
+        post_id: post.id,
+      })
+      console.log(res)
+    } catch (e) {
+      if (e instanceof HttpError) {
+        console.error(e.message)
       }
-    },
-    [authHeaderParams],
-  )
+    }
+  }, [])
 
   return { addBookmark }
 }
 
 export const useRemoveBookmark = (selectedFolder: number, post: Post) => {
-  const authHeaderParams = useAuthHeaderParams()
-
   const { data: bookmarkPosts, mutate: postsMutate } = useGetApi<BookmarkPosts>(
     `/folders/${selectedFolder}`,
     undefined,
-    authHeaderParams,
   )
 
   const removeBookmark = useCallback(async () => {
     try {
-      const res = await deleteApi(
-        `/folders/bookmarks/${post.bookmark?.id}`,
-        {},
-        authHeaderParams,
-      )
+      const res = await deleteApi(`/folders/bookmarks/${post.bookmark?.id}`, {})
       if (!bookmarkPosts) {
         return
       }
@@ -63,7 +49,7 @@ export const useRemoveBookmark = (selectedFolder: number, post: Post) => {
         console.error(e.message)
       }
     }
-  }, [authHeaderParams, bookmarkPosts, post.bookmark?.id, postsMutate])
+  }, [bookmarkPosts, post.bookmark?.id, postsMutate])
 
   return { removeBookmark }
 }

--- a/src/hooks/useFolder.ts
+++ b/src/hooks/useFolder.ts
@@ -4,10 +4,8 @@ import { Folder } from 'types/bookmark'
 import { postApi, HttpError, putApi, deleteApi } from 'utils/api'
 
 export const useCreateFolder = () => {
-  const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
-    '/folders',
-    undefined,
-  )
+  const { data: folders, mutate: mutateFolders } =
+    useGetApi<Folder[]>('/folders')
 
   const createFolder = useCallback(
     async (bookmarkName: string) => {
@@ -32,10 +30,8 @@ export const useCreateFolder = () => {
 }
 
 export const useUpdateFolder = () => {
-  const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
-    '/folders',
-    undefined,
-  )
+  const { data: folders, mutate: mutateFolders } =
+    useGetApi<Folder[]>('/folders')
 
   const updateFolder = useCallback(
     async (id: number, editFolderName: string) => {
@@ -68,10 +64,8 @@ export const useUpdateFolder = () => {
 }
 
 export const useDeleteFolder = () => {
-  const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
-    '/folders',
-    undefined,
-  )
+  const { data: folders, mutate: mutateFolders } =
+    useGetApi<Folder[]>('/folders')
 
   const deleteFolder = useCallback(
     async (id: number) => {

--- a/src/hooks/useFolder.ts
+++ b/src/hooks/useFolder.ts
@@ -1,26 +1,18 @@
 import { useCallback } from 'react'
-import { useAuthHeaderParams } from './login/useAuth'
 import { useGetApi } from './useApi'
 import { Folder } from 'types/bookmark'
 import { postApi, HttpError, putApi, deleteApi } from 'utils/api'
 
 export const useCreateFolder = () => {
-  const authHeaderParams = useAuthHeaderParams()
-
   const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
     '/folders',
     undefined,
-    authHeaderParams,
   )
 
   const createFolder = useCallback(
     async (bookmarkName: string) => {
       try {
-        const res = await postApi<Folder>(
-          '/folders',
-          { name: bookmarkName },
-          authHeaderParams,
-        )
+        const res = await postApi<Folder>('/folders', { name: bookmarkName })
         if (res && folders) {
           console.log('フォルダの作成に成功 ', res)
           mutateFolders([...folders, res], false)
@@ -33,29 +25,24 @@ export const useCreateFolder = () => {
         }
       }
     },
-    [authHeaderParams, folders, mutateFolders],
+    [folders, mutateFolders],
   )
 
   return { createFolder }
 }
 
 export const useUpdateFolder = () => {
-  const authHeaderParams = useAuthHeaderParams()
-
   const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
     '/folders',
     undefined,
-    authHeaderParams,
   )
 
   const updateFolder = useCallback(
     async (id: number, editFolderName: string) => {
       try {
-        const res = await putApi<Folder>(
-          `/folders/${id}`,
-          { name: editFolderName },
-          authHeaderParams,
-        )
+        const res = await putApi<Folder>(`/folders/${id}`, {
+          name: editFolderName,
+        })
         if (!res || !folders) {
           return
         }
@@ -75,24 +62,21 @@ export const useUpdateFolder = () => {
         }
       }
     },
-    [authHeaderParams, folders, mutateFolders],
+    [folders, mutateFolders],
   )
   return { updateFolder }
 }
 
 export const useDeleteFolder = () => {
-  const authHeaderParams = useAuthHeaderParams()
-
   const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
     '/folders',
     undefined,
-    authHeaderParams,
   )
 
   const deleteFolder = useCallback(
     async (id: number) => {
       try {
-        const res = await deleteApi(`/folders/${id}`, {}, authHeaderParams)
+        const res = await deleteApi(`/folders/${id}`)
         const newFolders = folders?.filter((folder) => folder.id !== id)
         mutateFolders(newFolders)
 
@@ -103,7 +87,7 @@ export const useDeleteFolder = () => {
         }
       }
     },
-    [authHeaderParams, folders, mutateFolders],
+    [folders, mutateFolders],
   )
 
   return { deleteFolder }

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -65,7 +65,7 @@ export const useDeletePost = (post: Post) => {
 
   const deletePost = useCallback(async () => {
     try {
-      const res = await deleteApi(`/posts/${post.id}`, undefined)
+      const res = await deleteApi(`/posts/${post.id}`)
       if (!posts) {
         return
       }

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -1,19 +1,17 @@
 import { useRouter } from 'next/router'
 import { useCallback } from 'react'
-import { useAuthHeaderParams } from 'hooks/login/useAuth'
 import { useGetApi } from 'hooks/useApi'
 import { Post, PostRequestParams } from 'types/post'
 import { deleteApi, HttpError, postApi, putApi } from 'utils/api'
 
 export const useCreatePost = () => {
   const { data: posts, mutate } = useGetApi<Post[]>('/posts')
-  const authHeaderParams = useAuthHeaderParams()
   const router = useRouter()
 
   const createPost = useCallback(
     async (params: PostRequestParams) => {
       try {
-        const newPost = await postApi<Post>('/posts', params, authHeaderParams)
+        const newPost = await postApi<Post>('/posts', params)
         if (newPost && posts) {
           console.log('投稿の作成に成功 ', newPost)
           router.push('/')
@@ -25,7 +23,7 @@ export const useCreatePost = () => {
         }
       }
     },
-    [authHeaderParams, mutate, posts, router],
+    [mutate, posts, router],
   )
 
   return { createPost }
@@ -33,16 +31,11 @@ export const useCreatePost = () => {
 
 export const useUpdatePost = (post: Post) => {
   const { data: posts, mutate } = useGetApi<Post[]>('/posts')
-  const authHeaderParams = useAuthHeaderParams()
 
   const updatePost = useCallback(
     async (params: PostRequestParams) => {
       try {
-        const res = await putApi<Post>(
-          `/posts/${post.id}`,
-          params,
-          authHeaderParams,
-        )
+        const res = await putApi<Post>(`/posts/${post.id}`, params)
         if (!res || !posts) {
           return
         }
@@ -61,7 +54,7 @@ export const useUpdatePost = (post: Post) => {
         }
       }
     },
-    [authHeaderParams, mutate, post.id, posts],
+    [mutate, post.id, posts],
   )
 
   return { updatePost }
@@ -69,15 +62,10 @@ export const useUpdatePost = (post: Post) => {
 
 export const useDeletePost = (post: Post) => {
   const { data: posts, mutate } = useGetApi<Post[]>('/posts')
-  const authHeaderParams = useAuthHeaderParams()
 
   const deletePost = useCallback(async () => {
     try {
-      const res = await deleteApi(
-        `/posts/${post.id}`,
-        undefined,
-        authHeaderParams,
-      )
+      const res = await deleteApi(`/posts/${post.id}`, undefined)
       if (!posts) {
         return
       }
@@ -90,7 +78,7 @@ export const useDeletePost = (post: Post) => {
         console.error(e.message)
       }
     }
-  }, [authHeaderParams, mutate, post.id, posts])
+  }, [mutate, post.id, posts])
 
   return { deletePost }
 }

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -12,11 +12,10 @@ const Bookmark: NextPage = () => {
   useRequireLogin()
   const [selectedFolderIndex, setSelectedFolderIndex] = useState(0)
 
-  const { data: folders } = useGetApi<Folder[]>('/folders', undefined)
+  const { data: folders } = useGetApi<Folder[]>('/folders')
 
   const { data: bookmarkPosts } = useGetApi<BookmarkPosts>(
     `/folders/${folders && folders[selectedFolderIndex]?.id}`,
-    undefined,
   )
 
   return (

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -4,26 +4,19 @@ import { BookmarkFolderList } from 'components/bookmark/BookmarkFolderList'
 import { CreateFolderField } from 'components/bookmark/CreateFolderField'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
-import { useAuthHeaderParams } from 'hooks/login/useAuth'
 import { useRequireLogin } from 'hooks/login/useRequireLogin'
 import { useGetApi } from 'hooks/useApi'
 import { Folder, BookmarkPosts } from 'types/bookmark'
 
 const Bookmark: NextPage = () => {
   useRequireLogin()
-  const authHeaderParams = useAuthHeaderParams()
   const [selectedFolderIndex, setSelectedFolderIndex] = useState(0)
 
-  const { data: folders } = useGetApi<Folder[]>(
-    '/folders',
-    undefined,
-    authHeaderParams,
-  )
+  const { data: folders } = useGetApi<Folder[]>('/folders', undefined)
 
   const { data: bookmarkPosts } = useGetApi<BookmarkPosts>(
     `/folders/${folders && folders[selectedFolderIndex]?.id}`,
     undefined,
-    authHeaderParams,
   )
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { deleteApi } from 'utils/api'
 const Home: NextPage = () => {
   const { data: posts, error } = useGetApi<Post[]>('/posts')
   if (false) {
-    deleteApi('/posts/delete_all', undefined)
+    deleteApi('/posts/delete_all')
   }
   const [stars, setStars] = useState(1)
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,16 +3,14 @@ import Head from 'next/head'
 import { useState } from 'react'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
-import { useAuthHeaderParams } from 'hooks/login/useAuth'
 import { useGetApi } from 'hooks/useApi'
 import { Post } from 'types/post'
 import { deleteApi } from 'utils/api'
 
 const Home: NextPage = () => {
   const { data: posts, error } = useGetApi<Post[]>('/posts')
-  const authHeaderParams = useAuthHeaderParams()
   if (false) {
-    deleteApi('/posts/delete_all', undefined, authHeaderParams)
+    deleteApi('/posts/delete_all', undefined)
   }
   const [stars, setStars] = useState(1)
 

--- a/src/pages/myPage.tsx
+++ b/src/pages/myPage.tsx
@@ -21,9 +21,9 @@ type MyPosts = {
 const MyPage: NextPage = () => {
   useRequireLogin()
   const [selectedPublished, setSelectedPublished] = useState(true)
-  const { cookies } = useCookies('userInfo')
+  const { cookies } = useCookies('user_info')
   const { data: myPosts } = useGetApi<MyPosts>(
-    `/users/${cookies.userInfo?.id}`,
+    `/users/${cookies.user_info?.id}`,
     undefined,
   )
 

--- a/src/pages/myPage.tsx
+++ b/src/pages/myPage.tsx
@@ -7,8 +7,8 @@ import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
 import { useRequireLogin } from 'hooks/login/useRequireLogin'
 import { useGetApi } from 'hooks/useApi'
-import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
+import { User } from 'types/user/user'
 
 type MyPosts = {
   user: {
@@ -21,11 +21,8 @@ type MyPosts = {
 const MyPage: NextPage = () => {
   useRequireLogin()
   const [selectedPublished, setSelectedPublished] = useState(true)
-  const { cookies } = useCookies('user_info')
-  const { data: myPosts } = useGetApi<MyPosts>(
-    `/users/${cookies.user_info?.id}`,
-    undefined,
-  )
+  const { data: user } = useGetApi<User>('/users/me')
+  const { data: myPosts } = useGetApi<MyPosts>(`/users/${user?.id}`)
 
   return (
     <Layout>

--- a/src/pages/myPage.tsx
+++ b/src/pages/myPage.tsx
@@ -5,7 +5,6 @@ import { AiOutlineUser as AiOutlineUserIcon } from 'react-icons/ai'
 
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
-import { useAuthHeaderParams } from 'hooks/login/useAuth'
 import { useRequireLogin } from 'hooks/login/useRequireLogin'
 import { useGetApi } from 'hooks/useApi'
 import { useCookies } from 'stores/useCookies'
@@ -23,11 +22,9 @@ const MyPage: NextPage = () => {
   useRequireLogin()
   const [selectedPublished, setSelectedPublished] = useState(true)
   const { cookies } = useCookies('userInfo')
-  const authHeaderParams = useAuthHeaderParams()
   const { data: myPosts } = useGetApi<MyPosts>(
     `/users/${cookies.userInfo?.id}`,
     undefined,
-    authHeaderParams,
   )
 
   return (

--- a/src/stores/useCookies.ts
+++ b/src/stores/useCookies.ts
@@ -3,14 +3,14 @@ import { useCookies as useCookiesOriginal } from 'react-cookie'
 
 type Cookies = {
   token: string
-  userInfo: {
+  user_info: {
     id: number
     username: string
   }
 }
 
 // 1つだけなら useCookies("token")
-// 2つ以上なら useCookies(["token","userInfo"])
+// 2つ以上なら useCookies(["token","user_info"])
 export const useCookies = <
   Key extends keyof Cookies,
   Data extends Cookies[Key],

--- a/src/stores/useCookies.ts
+++ b/src/stores/useCookies.ts
@@ -1,13 +1,7 @@
 import { useCallback } from 'react'
 import { useCookies as useCookiesOriginal } from 'react-cookie'
 
-type Cookies = {
-  token: string
-  user_info: {
-    id: number
-    username: string
-  }
-}
+type Cookies = {}
 
 // 1つだけなら useCookies("token")
 // 2つ以上なら useCookies(["token","user_info"])

--- a/src/stores/useGlobalState.ts
+++ b/src/stores/useGlobalState.ts
@@ -1,8 +1,6 @@
 import useSWR, { KeyedMutator } from 'swr'
 
-type GlobalState = {
-  isLoggedIn: boolean
-}
+type GlobalState = {}
 
 export const useGlobalState = <
   Path extends keyof GlobalState,

--- a/src/types/user/user.ts
+++ b/src/types/user/user.ts
@@ -1,9 +1,8 @@
 // ユーザー情報更新
 export type User = {
+  id: number
+  username: string
   email: string
   createdAt: string
-  id: number
-  token: string
   updatedAt: string
-  username: string
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,8 +2,7 @@ import { isEmptyObj } from './isEmptyObj'
 import { toCamelCaseObj } from './toCamelCaseObj'
 import { Res } from 'types/response'
 
-// export const BASE_URL = 'https://share-pos.herokuapp.com/api/v1'
-export const BASE_URL = 'http://localhost:3001/api/v1'
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
 
 type Method = 'GET' | 'POST' | 'PUT' | 'DELETE'
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,7 +2,8 @@ import { isEmptyObj } from './isEmptyObj'
 import { toCamelCaseObj } from './toCamelCaseObj'
 import { Res } from 'types/response'
 
-export const BASE_URL = 'https://share-pos.herokuapp.com/api/v1'
+// export const BASE_URL = 'https://share-pos.herokuapp.com/api/v1'
+export const BASE_URL = 'http://localhost:3001/api/v1'
 
 type Method = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
@@ -51,6 +52,8 @@ export const fetchApi = async <T>(
         ? undefined
         : JSON.stringify(requestParams),
       headers: { ...requestHeaders },
+      mode: 'cors',
+      credentials: 'include',
     })
 
     if (!res.ok) {


### PR DESCRIPTION
## 詳細
以前は、ログインに成功時にフロントがトークンを取得して、Cookieに格納して、認証が必要なAPIを叩く時にheaderにトークンを格納していた

今回の実装では、ログインに成功時にバックエンドが、フロントのCookieに暗号化したトークンを格納する。そして、認証が必要な時にフロントのCookieを取得して認証するように変更した。

- フロントのCookieの操作を全て消す。
- フロントが、認証が必要な時にauthHeaderParamsを送る処理を全て消す。
- ログインしているかを、ページ毎に`users/me ` にアクセスすることで判断している。
- ログアウトの処理を、バックエンドの `auth/logout` にお願いする
- バックエンドのURLをenvファイルに移動

## 動作確認

![SharePos 投稿一覧ページ - 職場 - Microsoft​ Edge 2022-09-16 22-40-33](https://user-images.githubusercontent.com/88410576/190653363-1713d849-3081-4742-80d6-6eaf45fb8723.gif)

