### PR TITLE
ヘッダーとフッターを修正

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -78,10 +78,10 @@ export const Footer: FC = () => {
           <Link href={menuIcon.href} key={menuIcon.href}>
             <div
               className={`cursor-pointer py-2 px-3 ${
-                router.pathname === menuIcon.href && 'text-primary'
+                router.asPath === menuIcon.href && 'text-primary'
               }`}
             >
-              {router.pathname === menuIcon.href
+              {router.asPath === menuIcon.href
                 ? menuIcon.selected
                 : menuIcon.default}
             </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -21,7 +21,24 @@ export const Footer: FC = () => {
 
   // ログインしてる時だけ表示
   if (error) {
-    return <></>
+    return (
+      <footer className=' bg-primary w-full py-2 bottom-0 z-2 fixed'>
+        <div className='flex mx-4 gap-3 justify-end items-center '>
+          <Link href='/login'>
+            {/* <a className='border-white border rounded-full font-bold text-white py-1 px-2 duration-300 hover:(text-primary bg-white) '> */}
+            <a className='border-white border rounded-full font-bold text-white py-1 px-2 duration-300'>
+              ログイン
+            </a>
+          </Link>
+          <Link href='/signup'>
+            {/* <a className='bg-white border-primary border rounded-full font-bold text-primary py-1 px-2 duration-300 hover:(text-white bg-primary) '> */}
+            <a className='bg-white border-primary border rounded-full font-bold text-primary py-1 px-2 duration-300'>
+              新規登録
+            </a>
+          </Link>
+        </div>
+      </footer>
+    )
   }
 
   const menuIcons: {
@@ -50,7 +67,7 @@ export const Footer: FC = () => {
   return (
     <footer className='sm:hidden'>
       {router.pathname !== '/create' && (
-        <button className='border rounded-full font-bold bg-primary border-primary text-white text-right p-2 right-20px bottom-50px text-30px z-2 fixed'>
+        <button className='bg-primary border border-primary rounded-full font-bold text-white text-right p-2 right-20px bottom-50px text-30px z-2 fixed'>
           <Link href='/create'>＋</Link>
         </button>
       )}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,10 +8,12 @@ import {
   AiOutlineUser as AiOutlineUserIcon,
 } from 'react-icons/ai'
 import { FaUser as FaUserIcon } from 'react-icons/fa'
+import { HiPaperAirplane as HiPaperAirplaneIcon } from 'react-icons/hi'
 import {
   IoBook as IoBookIcon,
   IoBookOutline as IoBookOutlineIcon,
 } from 'react-icons/io5'
+
 import { useGetApi } from 'hooks/useApi'
 import { User } from 'types/user/user'
 
@@ -66,7 +68,9 @@ export const Footer: FC = () => {
     <footer className='sm:hidden'>
       {router.pathname !== '/create' && (
         <button className='bg-primary border border-primary rounded-full font-bold text-white text-right p-2 right-20px bottom-50px text-30px z-2 fixed'>
-          <Link href='/create'>＋</Link>
+          <Link href='/create'>
+            <HiPaperAirplaneIcon className='h-7 transform w-7 rotate-90' />
+          </Link>
         </button>
       )}
       <nav className='bg-white flex w-full bottom-0 text-25px z-2 justify-around fixed'>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -23,15 +23,13 @@ export const Footer: FC = () => {
   if (error) {
     return (
       <footer className=' bg-primary w-full py-2 bottom-0 z-2 fixed'>
-        <div className='flex mx-4 gap-3 justify-end items-center '>
+        <div className='flex pr-4 gap-3 justify-end sm:justify-center'>
           <Link href='/login'>
-            {/* <a className='border-white border rounded-full font-bold text-white py-1 px-2 duration-300 hover:(text-primary bg-white) '> */}
             <a className='border-white border rounded-full font-bold text-white py-1 px-2 duration-300'>
               ログイン
             </a>
           </Link>
           <Link href='/signup'>
-            {/* <a className='bg-white border-primary border rounded-full font-bold text-primary py-1 px-2 duration-300 hover:(text-white bg-primary) '> */}
             <a className='bg-white border-primary border rounded-full font-bold text-primary py-1 px-2 duration-300'>
               新規登録
             </a>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -39,33 +39,33 @@ export const Header: FC = () => {
               />
             </div>
             {isLoggedIn ? (
-              <div className='flex gap-3 justify-end items-center'>
-                <Link href='/create'>
-                  <div className='cursor-pointer flex gap-0.5 items-center'>
-                    {/* <div className='duration-300 hover:(underline) '> */}
-                    <div className='duration-300 hidden sm:block hover:(underline) '>
-                      投稿する
+              <div className='flex gap-3'>
+                <div className='gap-3 hidden items-center sm:flex'>
+                  <Link href='/create'>
+                    <div className='cursor-pointer flex gap-0.5 items-center'>
+                      <div className='duration-300 hover:(underline) '>
+                        投稿する
+                      </div>
+                      <BsPencilSquareIcon />
                     </div>
-                    <BsPencilSquareIcon />
-                  </div>
-                </Link>
-                <Link href='/bookmark'>
-                  <div className='cursor-pointer flex gap-0.5 items-center'>
-                    <div className='duration-300 hidden sm:block hover:(underline) '>
-                      ブックマーク
+                  </Link>
+                  <Link href='/bookmark'>
+                    <div className='cursor-pointer flex gap-0.5 items-center'>
+                      <div className='duration-300 hover:(underline) '>
+                        ブックマーク
+                      </div>
+                      <HiOutlineBookOpenIcon />
                     </div>
-                    <HiOutlineBookOpenIcon />
-                  </div>
-                </Link>
-                <Link href={`/users/${user?.id}`}>
-                  <div className='cursor-pointer flex gap-0.5 items-center'>
-                    {/* <div className='duration-300 hover:(underline) '> */}
-                    <div className='duration-300 hidden sm:block hover:(underline) '>
-                      マイページ
+                  </Link>
+                  <Link href={`/users/${user?.id}`}>
+                    <div className='cursor-pointer flex gap-0.5 items-center'>
+                      <div className='duration-300 hover:(underline) '>
+                        マイページ
+                      </div>
+                      <AiOutlineUserIcon />
                     </div>
-                    <AiOutlineUserIcon />
-                  </div>
-                </Link>
+                  </Link>
+                </div>
                 <div
                   onClick={logOut}
                   className='cursor-pointer duration-300 hover:(underline) '

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,8 +20,8 @@ export const Header: FC = () => {
 
   return (
     <>
-      <header className='bg-white w-full py-2 top-0 z-10 fixed'>
-        {/* <header className='bg-white w-full py-2 top-0 z-100 sticky'> */}
+      {/* <header className='bg-white w-full py-2 top-0 z-10 sm:fixed'> */}
+      <header className='bg-white w-full py-2 top-0 z-100 sm:sticky'>
         <nav className='flex mx-4 items-center justify-between'>
           <Link href='/'>
             <h1 className='cursor-pointer mt-0 text-primary  mb-1 text-4xl sm:text-6xl'>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react'
 import { Footer } from './Footer'
-import { Header } from './Header'
+import { Header } from './header/Header'
 
 type Props = {
   children: ReactNode

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,12 +9,11 @@ type Props = {
 export const Layout: FC<Props> = ({ children }) => {
   return (
     <>
-      <div className='min-h-screen grid grid-rows-[auto,1fr]'>
+      <div className='bg-base min-h-screen'>
         <Header />
-        {/* <main className='bg-base min-h-100vh'> */}
-        <main className='bg-base'>
-          {/* <div className='mx-auto w-screen max-w-1150px px-4 pt-100px pb-70px sm:pt-130px'> */}
-          <div className='mx-auto max-w-1150px px-4 pt-100px pb-70px w-100vw sm:pt-130px'>
+        <main>
+          {/* <div className='mx-auto max-w-1150px px-4 pt-100px pb-70px sm:pt-130px'> */}
+          <div className='mx-auto max-w-1150px px-4 pt-50px pb-70px'>
             {children}
           </div>
         </main>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -12,7 +12,6 @@ export const Layout: FC<Props> = ({ children }) => {
       <div className='bg-base min-h-screen'>
         <Header />
         <main>
-          {/* <div className='mx-auto max-w-1150px px-4 pt-100px pb-70px sm:pt-130px'> */}
           <div className='mx-auto max-w-1150px px-4 pt-50px pb-70px'>
             {children}
           </div>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,12 +9,16 @@ type Props = {
 export const Layout: FC<Props> = ({ children }) => {
   return (
     <>
-      <Header />
-      <main className='bg-base min-h-100vh'>
-        <div className='mx-auto max-w-1150px px-4 pt-100px pb-70px break-words sm:pt-130px'>
-          {children}
-        </div>
-      </main>
+      <div className='min-h-screen grid grid-rows-[auto,1fr]'>
+        <Header />
+        {/* <main className='bg-base min-h-100vh'> */}
+        <main className='bg-base'>
+          {/* <div className='mx-auto w-screen max-w-1150px px-4 pt-100px pb-70px sm:pt-130px'> */}
+          <div className='mx-auto max-w-1150px px-4 pt-100px pb-70px w-100vw sm:pt-130px'>
+            {children}
+          </div>
+        </main>
+      </div>
 
       <Footer />
     </>

--- a/src/components/layout/header/DropDownMenu.tsx
+++ b/src/components/layout/header/DropDownMenu.tsx
@@ -1,15 +1,26 @@
+import Link from 'next/link'
 import { FC, useState } from 'react'
+import { AiOutlineUser as AiOutlineUserIcon } from 'react-icons/ai'
 import { FaUserCircle as FaUserCircleIcon } from 'react-icons/fa'
+import {
+  FiLogOut as FiLogOutIcon,
+  FiSettings as FiSettingsIcon,
+} from 'react-icons/fi'
+import { HiOutlineBookOpen as HiOutlineBookOpenIcon } from 'react-icons/hi'
 import { useLogOut } from 'hooks/login/useAuth'
+import { useGetApi } from 'hooks/useApi'
+import { User } from 'types/user/user'
 
 export const DropDownMenu: FC = () => {
   const { logOut } = useLogOut()
+  const { data: user } = useGetApi<User>('/users/me')
+
   const [isOpenMenu, setIsOpenMenu] = useState(false)
 
   return (
     <div>
       <div className='flex' onClick={() => setIsOpenMenu(s => !s)}>
-        <FaUserCircleIcon className='cursor-pointer h-10 w-10' />
+        <FaUserCircleIcon className='cursor-pointer h-8 w-8' />
       </div>
 
       {isOpenMenu && (
@@ -20,15 +31,29 @@ export const DropDownMenu: FC = () => {
             aria-hidden='true'
           />
 
-          <div className='bg-white shadow-lg top-5px right-0 w-40 z-2 absolute'>
-            <button className='flex text-left py-1 px-4 gap-1 items-center hover:bg-base'>
-              ユーザー情報を編集
+          <div className='bg-white shadow-xl top-10px right-[-20px] w-37 z-200 absolute'>
+            <Link href='/bookmark'>
+              <div className='cursor-pointer flex py-1 pl-4 gap-2 items-center hover:bg-base'>
+                <HiOutlineBookOpenIcon />
+                ブックマーク
+              </div>
+            </Link>
+            <Link href={`/users/${user?.id}`}>
+              <div className='cursor-pointer flex py-1 pl-4 gap-2 items-center hover:bg-base'>
+                <AiOutlineUserIcon />
+                マイページ
+              </div>
+            </Link>
+            <button className='flex text-left w-full py-1 pl-4 gap-2 items-center hover:bg-base'>
+              <FiSettingsIcon />
+              ユーザー情報
             </button>
 
             <button
-              className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-base'
+              className='flex text-left w-full py-1 pl-4 gap-2 items-center hover:bg-base'
               onClick={logOut}
             >
+              <FiLogOutIcon />
               ログアウト
             </button>
           </div>

--- a/src/components/layout/header/DropDownMenu.tsx
+++ b/src/components/layout/header/DropDownMenu.tsx
@@ -7,6 +7,7 @@ import {
   FiSettings as FiSettingsIcon,
 } from 'react-icons/fi'
 import { HiOutlineBookOpen as HiOutlineBookOpenIcon } from 'react-icons/hi'
+
 import { useLogOut } from 'hooks/login/useAuth'
 import { useGetApi } from 'hooks/useApi'
 import { User } from 'types/user/user'
@@ -31,7 +32,7 @@ export const DropDownMenu: FC = () => {
             aria-hidden='true'
           />
 
-          <div className='bg-white shadow-xl top-10px right-[-20px] w-40 z-200 absolute'>
+          <div className='bg-white shadow-xl top-10px right-[-15px] w-40 z-200 absolute'>
             <Link href='/bookmark'>
               <div className='cursor-pointer py-2 pl-4 gap-2 hidden items-center sm:flex hover:bg-base'>
                 <HiOutlineBookOpenIcon />

--- a/src/components/layout/header/DropDownMenu.tsx
+++ b/src/components/layout/header/DropDownMenu.tsx
@@ -1,0 +1,39 @@
+import { FC, useState } from 'react'
+import { FaUserCircle as FaUserCircleIcon } from 'react-icons/fa'
+import { useLogOut } from 'hooks/login/useAuth'
+
+export const DropDownMenu: FC = () => {
+  const { logOut } = useLogOut()
+  const [isOpenMenu, setIsOpenMenu] = useState(false)
+
+  return (
+    <div>
+      {/* <div
+        onClick={logOut}
+        className='cursor-pointer duration-300 hover:(underline) '
+      >
+        <FaUserCircleIcon className='h-10 w-10' />
+      </div> */}
+      <div
+        onClick={() => setIsOpenMenu(s => !s)}
+        className='cursor-pointer duration-300 hover:(underline) '
+      >
+        <FaUserCircleIcon className='h-10 w-10' />
+      </div>
+      {isOpenMenu && (
+        <div className='bg-white shadow-lg top-70px right-20px absolute'>
+          <div className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-base'>
+            ユーザー情報を編集
+          </div>
+
+          <div
+            className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-base'
+            onClick={logOut}
+          >
+            ログアウト
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/header/DropDownMenu.tsx
+++ b/src/components/layout/header/DropDownMenu.tsx
@@ -8,29 +8,29 @@ export const DropDownMenu: FC = () => {
 
   return (
     <div>
-      {/* <div
-        onClick={logOut}
-        className='cursor-pointer duration-300 hover:(underline) '
-      >
-        <FaUserCircleIcon className='h-10 w-10' />
-      </div> */}
-      <div
-        onClick={() => setIsOpenMenu(s => !s)}
-        className='cursor-pointer duration-300 hover:(underline) '
-      >
-        <FaUserCircleIcon className='h-10 w-10' />
+      <div className='flex' onClick={() => setIsOpenMenu(s => !s)}>
+        <FaUserCircleIcon className='cursor-pointer h-10 w-10' />
       </div>
-      {isOpenMenu && (
-        <div className='bg-white shadow-lg top-70px right-20px absolute'>
-          <div className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-base'>
-            ユーザー情報を編集
-          </div>
 
+      {isOpenMenu && (
+        <div className='relative'>
           <div
-            className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-base'
-            onClick={logOut}
-          >
-            ログアウト
+            onClick={() => setIsOpenMenu(false)}
+            className='h-100vh top-0 left-0 w-100vw z-1 fixed'
+            aria-hidden='true'
+          />
+
+          <div className='bg-white shadow-lg top-5px right-0 w-40 z-2 absolute'>
+            <button className='flex text-left py-1 px-4 gap-1 items-center hover:bg-base'>
+              ユーザー情報を編集
+            </button>
+
+            <button
+              className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-base'
+              onClick={logOut}
+            >
+              ログアウト
+            </button>
           </div>
         </div>
       )}

--- a/src/components/layout/header/DropDownMenu.tsx
+++ b/src/components/layout/header/DropDownMenu.tsx
@@ -31,26 +31,25 @@ export const DropDownMenu: FC = () => {
             aria-hidden='true'
           />
 
-          <div className='bg-white shadow-xl top-10px right-[-20px] w-37 z-200 absolute'>
+          <div className='bg-white shadow-xl top-10px right-[-20px] w-40 z-200 absolute'>
             <Link href='/bookmark'>
-              <div className='cursor-pointer flex py-1 pl-4 gap-2 items-center hover:bg-base'>
+              <div className='cursor-pointer py-2 pl-4 gap-2 hidden items-center sm:flex hover:bg-base'>
                 <HiOutlineBookOpenIcon />
                 ブックマーク
               </div>
             </Link>
             <Link href={`/users/${user?.id}`}>
-              <div className='cursor-pointer flex py-1 pl-4 gap-2 items-center hover:bg-base'>
+              <div className='cursor-pointer py-2 pl-4 gap-2 hidden items-center sm:flex hover:bg-base'>
                 <AiOutlineUserIcon />
                 マイページ
               </div>
             </Link>
-            <button className='flex text-left w-full py-1 pl-4 gap-2 items-center hover:bg-base'>
+            <button className='flex text-left w-full py-2 pl-4 gap-2 items-center hover:bg-base'>
               <FiSettingsIcon />
               ユーザー情報
             </button>
-
             <button
-              className='flex text-left w-full py-1 pl-4 gap-2 items-center hover:bg-base'
+              className='flex text-left w-full py-2 pl-4 gap-2 items-center hover:bg-base'
               onClick={logOut}
             >
               <FiLogOutIcon />

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -19,7 +19,6 @@ export const Header: FC = () => {
 
   return (
     <>
-      {/* <header className='bg-white w-full py-2 top-0 z-10 sm:fixed'> */}
       <header className='bg-white w-full py-2 top-0 z-100 sm:sticky'>
         <nav className='flex mx-4 items-center justify-between'>
           <Link href='/'>
@@ -29,8 +28,7 @@ export const Header: FC = () => {
           </Link>
 
           <div className='flex gap-3 justify-end items-center'>
-            {/* <div className='gap-3 hidden justify-end items-center sm:flex'> */}
-            <AiOutlineSearchIcon className='cursor-pointer mt-1' />
+            <AiOutlineSearchIcon className='cursor-pointer h-6 mt-1 w-6' />
             <div className='hidden'>
               <input
                 type='text'
@@ -38,7 +36,7 @@ export const Header: FC = () => {
               />
             </div>
             {isLoggedIn ? (
-              <div className='flex gap-3'>
+              <div className='flex gap-3 items-center'>
                 <div className='gap-3 hidden items-center sm:flex'>
                   <Link href='/create'>
                     <div className='cursor-pointer flex gap-0.5 items-center'>
@@ -65,6 +63,7 @@ export const Header: FC = () => {
                     </div>
                   </Link>
                 </div>
+
                 <DropDownMenu />
               </div>
             ) : (

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -13,7 +13,7 @@ export const Header: FC = () => {
   return (
     <>
       <header className='bg-white w-full py-2 top-0 z-100 sm:sticky'>
-        <nav className='flex px-4 items-center justify-between'>
+        <nav className='flex mx-auto max-w-1150px px-4 items-center justify-between'>
           <Link href='/'>
             <h1 className='cursor-pointer mt-0 text-primary  mb-1 text-4xl'>
               SharePos

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -8,7 +8,7 @@ import {
 import { BsPencilSquare as BsPencilSquareIcon } from 'react-icons/bs'
 import { HiOutlineBookOpen as HiOutlineBookOpenIcon } from 'react-icons/hi'
 
-import { useLogOut } from 'hooks/login/useAuth'
+import { DropDownMenu } from './DropDownMenu'
 import { useIsLoggedIn } from 'hooks/login/useIsLoggedIn'
 import { useGetApi } from 'hooks/useApi'
 import { User } from 'types/user/user'
@@ -16,7 +16,6 @@ import { User } from 'types/user/user'
 export const Header: FC = () => {
   const isLoggedIn = useIsLoggedIn()
   const { data: user } = useGetApi<User>('/users/me')
-  const { logOut } = useLogOut()
 
   return (
     <>
@@ -66,12 +65,7 @@ export const Header: FC = () => {
                     </div>
                   </Link>
                 </div>
-                <div
-                  onClick={logOut}
-                  className='cursor-pointer duration-300 hover:(underline) '
-                >
-                  ログアウト
-                </div>
+                <DropDownMenu />
               </div>
             ) : (
               <div className='flex gap-2'>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,12 +1,8 @@
 import Link from 'next/link'
 import { FC } from 'react'
 
-import {
-  AiOutlineSearch as AiOutlineSearchIcon,
-  AiOutlineUser as AiOutlineUserIcon,
-} from 'react-icons/ai'
+import { AiOutlineSearch as AiOutlineSearchIcon } from 'react-icons/ai'
 import { BsPencilSquare as BsPencilSquareIcon } from 'react-icons/bs'
-import { HiOutlineBookOpen as HiOutlineBookOpenIcon } from 'react-icons/hi'
 
 import { DropDownMenu } from './DropDownMenu'
 import { useIsLoggedIn } from 'hooks/login/useIsLoggedIn'
@@ -37,7 +33,9 @@ export const Header: FC = () => {
             </div>
             {isLoggedIn ? (
               <div className='flex gap-3 items-center'>
-                <div className='gap-3 hidden items-center sm:flex'>
+                <DropDownMenu />
+                {/* <div className='gap-3 hidden items-center sm:flex'> */}
+                <div className='flex gap-3 items-center'>
                   <Link href='/create'>
                     <div className='cursor-pointer flex gap-0.5 items-center'>
                       <div className='duration-300 hover:(underline) '>
@@ -46,27 +44,39 @@ export const Header: FC = () => {
                       <BsPencilSquareIcon />
                     </div>
                   </Link>
-                  <Link href='/bookmark'>
-                    <div className='cursor-pointer flex gap-0.5 items-center'>
-                      <div className='duration-300 hover:(underline) '>
-                        ブックマーク
-                      </div>
-                      <HiOutlineBookOpenIcon />
-                    </div>
-                  </Link>
-                  <Link href={`/users/${user?.id}`}>
-                    <div className='cursor-pointer flex gap-0.5 items-center'>
-                      <div className='duration-300 hover:(underline) '>
-                        マイページ
-                      </div>
-                      <AiOutlineUserIcon />
-                    </div>
-                  </Link>
                 </div>
-
-                <DropDownMenu />
               </div>
             ) : (
+              // <div className='flex gap-3 items-center'>
+              //   <div className='gap-3 hidden items-center sm:flex'>
+              //     <Link href='/create'>
+              //       <div className='cursor-pointer flex gap-0.5 items-center'>
+              //         <div className='duration-300 hover:(underline) '>
+              //           投稿する
+              //         </div>
+              //         <BsPencilSquareIcon />
+              //       </div>
+              //     </Link>
+              //     <Link href='/bookmark'>
+              //       <div className='cursor-pointer flex gap-0.5 items-center'>
+              //         <div className='duration-300 hover:(underline) '>
+              //           ブックマーク
+              //         </div>
+              //         <HiOutlineBookOpenIcon />
+              //       </div>
+              //     </Link>
+              //     <Link href={`/users/${user?.id}`}>
+              //       <div className='cursor-pointer flex gap-0.5 items-center'>
+              //         <div className='duration-300 hover:(underline) '>
+              //           マイページ
+              //         </div>
+              //         <AiOutlineUserIcon />
+              //       </div>
+              //     </Link>
+              //   </div>
+
+              //   <DropDownMenu />
+              // </div>
               <div className='flex gap-2'>
                 <Link href='/login'>
                   <div className='cursor-pointer duration-300 hover:(underline) '>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -6,35 +6,27 @@ import { BsPencilSquare as BsPencilSquareIcon } from 'react-icons/bs'
 
 import { DropDownMenu } from './DropDownMenu'
 import { useIsLoggedIn } from 'hooks/login/useIsLoggedIn'
-import { useGetApi } from 'hooks/useApi'
-import { User } from 'types/user/user'
 
 export const Header: FC = () => {
   const isLoggedIn = useIsLoggedIn()
-  const { data: user } = useGetApi<User>('/users/me')
 
   return (
     <>
       <header className='bg-white w-full py-2 top-0 z-100 sm:sticky'>
         <nav className='flex mx-4 items-center justify-between'>
           <Link href='/'>
-            <h1 className='cursor-pointer mt-0 text-primary  mb-1 text-4xl sm:text-6xl'>
+            <h1 className='cursor-pointer mt-0 text-primary  mb-1 text-4xl'>
               SharePos
             </h1>
           </Link>
 
           <div className='flex gap-3 justify-end items-center'>
             <AiOutlineSearchIcon className='cursor-pointer h-6 mt-1 w-6' />
-            <div className='hidden'>
-              <input
-                type='text'
-                className='rounded-full ring-primary ring-1 focus:(ring-2 outline-none) '
-              />
-            </div>
+
             {isLoggedIn ? (
               <div className='flex gap-3 items-center'>
                 <DropDownMenu />
-                {/* <div className='gap-3 hidden items-center sm:flex'> */}
+
                 <div className='flex gap-3 items-center'>
                   <Link href='/create'>
                     <div className='cursor-pointer flex gap-0.5 items-center'>
@@ -47,36 +39,6 @@ export const Header: FC = () => {
                 </div>
               </div>
             ) : (
-              // <div className='flex gap-3 items-center'>
-              //   <div className='gap-3 hidden items-center sm:flex'>
-              //     <Link href='/create'>
-              //       <div className='cursor-pointer flex gap-0.5 items-center'>
-              //         <div className='duration-300 hover:(underline) '>
-              //           投稿する
-              //         </div>
-              //         <BsPencilSquareIcon />
-              //       </div>
-              //     </Link>
-              //     <Link href='/bookmark'>
-              //       <div className='cursor-pointer flex gap-0.5 items-center'>
-              //         <div className='duration-300 hover:(underline) '>
-              //           ブックマーク
-              //         </div>
-              //         <HiOutlineBookOpenIcon />
-              //       </div>
-              //     </Link>
-              //     <Link href={`/users/${user?.id}`}>
-              //       <div className='cursor-pointer flex gap-0.5 items-center'>
-              //         <div className='duration-300 hover:(underline) '>
-              //           マイページ
-              //         </div>
-              //         <AiOutlineUserIcon />
-              //       </div>
-              //     </Link>
-              //   </div>
-
-              //   <DropDownMenu />
-              // </div>
               <div className='flex gap-2'>
                 <Link href='/login'>
                   <div className='cursor-pointer duration-300 hover:(underline) '>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -13,7 +13,7 @@ export const Header: FC = () => {
   return (
     <>
       <header className='bg-white w-full py-2 top-0 z-100 sm:sticky'>
-        <nav className='flex mx-4 items-center justify-between'>
+        <nav className='flex px-4 items-center justify-between'>
           <Link href='/'>
             <h1 className='cursor-pointer mt-0 text-primary  mb-1 text-4xl'>
               SharePos

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,14 +1,16 @@
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { FC } from 'react'
 
 import { AiOutlineSearch as AiOutlineSearchIcon } from 'react-icons/ai'
-import { BsPencilSquare as BsPencilSquareIcon } from 'react-icons/bs'
+import { HiPaperAirplane as HiPaperAirplaneIcon } from 'react-icons/hi'
 
 import { DropDownMenu } from './DropDownMenu'
 import { useIsLoggedIn } from 'hooks/login/useIsLoggedIn'
 
 export const Header: FC = () => {
   const isLoggedIn = useIsLoggedIn()
+  const router = useRouter()
 
   return (
     <>
@@ -27,28 +29,26 @@ export const Header: FC = () => {
               <div className='flex gap-3 items-center'>
                 <DropDownMenu />
 
-                <div className='flex gap-3 items-center'>
-                  <Link href='/create'>
-                    <div className='cursor-pointer flex gap-0.5 items-center'>
-                      <div className='duration-300 hover:(underline) '>
-                        投稿する
-                      </div>
-                      <BsPencilSquareIcon />
-                    </div>
-                  </Link>
-                </div>
+                {router.pathname !== '/create' && (
+                  <div className='flex gap-3 items-center'>
+                    <Link href='/create'>
+                      <a className='bg-primary border border-primary flex rounded-7px text-white py-1 px-2 gap-1 duration-300 items-center hover:(bg-white text-primary) '>
+                        <div className='font-bold'>シェアする</div>
+                        <HiPaperAirplaneIcon className='transform rotate-90' />
+                      </a>
+                    </Link>
+                  </div>
+                )}
               </div>
             ) : (
-              <div className='flex gap-2'>
+              <div className='flex gap-2 items-center'>
                 <Link href='/login'>
-                  <div className='cursor-pointer duration-300 hover:(underline) '>
-                    ログイン
-                  </div>
+                  <a className='cursor-pointer'>ログイン</a>
                 </Link>
                 <Link href='/signup'>
-                  <div className='cursor-pointer duration-300 hover:(underline) '>
+                  <button className='bg-primary border border-primary rounded-7px text-white py-1 px-2 duration-300 hover:(bg-white text-primary) '>
                     新規登録
-                  </div>
+                  </button>
                 </Link>
               </div>
             )}

--- a/src/hooks/login/useAuth.ts
+++ b/src/hooks/login/useAuth.ts
@@ -67,9 +67,9 @@ export const useLogOut = () => {
 
   return {
     logOut: () => {
+      mutate(undefined, false)
       remove('token')
       console.log('logout')
-      mutate(undefined, false)
       router.push('/')
     },
   }

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -29,7 +29,7 @@ const Bookmark: NextPage = () => {
       <Layout>
         <div className='flex ml-4 justify-between'>
           <h1 className='font-bold text-2xl'>ブックマーク</h1>
-          <CreateFolderButton className='font-bold bg-primary rounded-10px text-white py-1 px-2' />
+          <CreateFolderButton className='bg-primary font-bold rounded-10px text-white py-1 px-2' />
         </div>
         <div className='mx-auto mt-20 w-300px'>
           <p>1. フォルダを作成してみよう！</p>
@@ -45,15 +45,15 @@ const Bookmark: NextPage = () => {
       <div className='flex ml-4 justify-between'>
         <h1 className='font-bold text-2xl'>ブックマーク</h1>
         <div className='sm:hidden'>
-          <CreateFolderButton className='font-bold bg-primary rounded-10px text-white py-1 px-2' />
+          <CreateFolderButton className='bg-primary font-bold rounded-10px text-white py-1 px-2' />
         </div>
       </div>
 
       <div className='sm:(flex gap-3 items-start) '>
         {/* 自分のフォルダ一覧 */}
-        <div className='bg-base pl-4 top-60px z-10 sticky sm:top-100px'>
+        <div className='bg-base pl-4 top-0px z-10 sticky sm:top-100px'>
           <div className='mt-4 w-190px hidden sm:block'>
-            <CreateFolderButton className='font-bold bg-primary rounded-10px text-white py-1 px-2' />
+            <CreateFolderButton className='bg-primary font-bold rounded-10px text-white py-1 px-2' />
           </div>
           <div className='mt-5'>
             <BookmarkFolderList folders={folders} />


### PR DESCRIPTION
## 詳細
- ヘッダーのメニューをシンプルに
  - ユーザーアイコンを追加し、タップでポップアップメニュー表示
  - ユーザーアイコンの中
    - パソコンの時は、ブックマーク・マイページ・ユーザー情報・ログアウト
    - スマホの時は、ユーザー情報・ログアウト
  - "投稿する" を、"シェアする" に変えて、アイコンを付ける
  - スマホの右下の + ボタンを、飛行機のアイコンに
- ヘッダーのmax-wを1150pxに
- ログイン前は、フッターにログイン・新規登録のボタンを表示する。

#  動作確認
## ログイン後
### before

![image](https://user-images.githubusercontent.com/88410576/198884808-0a08cbfb-fbfb-4e15-af30-223c3a75bb4d.png)

### after
![image](https://user-images.githubusercontent.com/88410576/198918660-9a77c14a-6170-4509-a813-98833f1c292b.png)


- パソコンの時
![image](https://user-images.githubusercontent.com/88410576/198918692-804f7db2-d9f4-42f7-9d2e-5b4d7c7aaf40.png)

- スマホの時
![image](https://user-images.githubusercontent.com/88410576/198918771-7f80e22a-c993-4108-8844-281972870d93.png)

## ログイン前
### before
![image](https://user-images.githubusercontent.com/88410576/198918949-d113818d-da2c-49a3-ac9a-68d489e5ff72.png)

### after

- パソコン
![image](https://user-images.githubusercontent.com/88410576/198919020-75bfe890-cc5b-4994-94e9-da18d338d584.png)


- スマホ
![image](https://user-images.githubusercontent.com/88410576/198918991-fd5d8581-01fc-432f-8803-7990a08f0a29.png)

