### PR TITLE
Postの返信コメント数を表示

### DIFF
--- a/src/components/layout/header/DropDownMenu.tsx
+++ b/src/components/layout/header/DropDownMenu.tsx
@@ -28,11 +28,11 @@ export const DropDownMenu: FC = () => {
         <div className='relative'>
           <div
             onClick={() => setIsOpenMenu(false)}
-            className='h-100vh top-0 left-0 w-100vw z-1 fixed'
+            className='h-100vh top-0 left-0 w-100vw fixed'
             aria-hidden='true'
           />
 
-          <div className='bg-white shadow-xl top-10px right-[-15px] w-40 z-200 absolute'>
+          <div className='bg-white shadow-xl top-10px right-[-15px] w-40 absolute'>
             <Link href='/bookmark'>
               <a className='cursor-pointer py-2 pl-4 gap-2 hidden items-center sm:flex hover:bg-base'>
                 <HiOutlineBookOpenIcon />

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -15,7 +15,7 @@ export const Header: FC = () => {
 
   return (
     <>
-      <header className='bg-white w-full py-2 top-0 z-100 sm:sticky'>
+      <header className='bg-white w-full py-2 top-0 z-2 sm:sticky'>
         <nav className='flex mx-auto max-w-1150px px-4 items-center justify-between'>
           <Link href='/'>
             <h1 className='cursor-pointer mt-0 text-primary  mb-1 text-4xl'>

--- a/src/components/post/Item/FolderList.tsx
+++ b/src/components/post/Item/FolderList.tsx
@@ -32,21 +32,20 @@ export const FolderList: FC<Props> = ({
         <div className='max-h-250px overflow-y-scroll scroll-bar-none sm:max-h-450px'>
           <CreateFolderButton radius='xs' />
 
-          {folders?.length &&
-            folders.map((folder, index) => (
-              <button
-                key={index}
-                className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-primary-light'
-                onClick={async () => {
-                  console.log('click! : ')
-                  onClickFolderName?.()
-                  await onAddBookmark?.(folder.id, post)
-                }}
-              >
-                <BsFolderIcon />
-                <p>{folder.name}</p>
-              </button>
-            ))}
+          {folders?.map((folder, index) => (
+            <button
+              key={index}
+              className='flex text-left w-full py-1 px-4 gap-1 items-center hover:bg-primary-light'
+              onClick={async () => {
+                console.log('click! : ')
+                onClickFolderName?.()
+                await onAddBookmark?.(folder.id, post)
+              }}
+            >
+              <BsFolderIcon />
+              <p>{folder.name}</p>
+            </button>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -70,29 +70,24 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
           <>
             <PostItemComment comment={post.comment} />
 
-            {/* urlのサムネイル画像等 */}
             <PostLinkCard post={post} />
 
-            <div className='flex mt-1 items-center justify-between'>
-              <div className='flex'>
-                {[...Array(post.evaluation)].map(v => (
-                  <div key={v}>☆</div>
-                ))}
-              </div>
-              <div className='text-13px'>{post.createdAt.substring(0, 10)}</div>
+            {/* 返信 */}
+            <div className='flex h-6 mt-2 items-center justify-between'>
+              {post.replyComments.length ? (
+                <Link href=''>
+                  <p className='cursor-pointer text-secondary'>
+                    {post.replyComments?.length}件の返信
+                  </p>
+                </Link>
+              ) : (
+                <p />
+              )}
+              <p className='text-13px'>{post.createdAt.substring(0, 10)}</p>
             </div>
           </>
         )}
       </div>
-
-      {/* コメント */}
-      {post.replyComments?.length !== 0 && (
-        <Link href=''>
-          <p className='cursor-pointer mt-1 text-secondary'>
-            {post.replyComments.length}件の返信
-          </p>
-        </Link>
-      )}
     </article>
   )
 }

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -86,14 +86,12 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
       </div>
 
       {/* コメント */}
-      {post.replyComments?.length ? (
+      {post.replyComments?.length !== 0 && (
         <Link href=''>
-          <p className='cursor-pointer text-secondary'>
+          <p className='cursor-pointer mt-1 text-secondary'>
             {post.replyComments.length}件の返信
           </p>
         </Link>
-      ) : (
-        ''
       )}
     </article>
   )

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -86,7 +86,7 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
       </div>
 
       {/* コメント */}
-      {post.replyComments.length ? (
+      {post.replyComments?.length ? (
         <Link href=''>
           <p className='cursor-pointer text-secondary'>
             {post.replyComments.length}件の返信

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -34,13 +34,6 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
           </a>
         </Link>
         <div className='flex gap-2'>
-          {/* {post.bookmark && (
-            <TbBookmarkOffIcon
-              className='cursor-pointer text-40px sm:text-30px'
-              onClick={removeBookmark}
-            />
-          )} */}
-
           {/* 右上の・・・ボタン */}
           <PostMenuButton
             post={post}
@@ -91,6 +84,17 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
           </>
         )}
       </div>
+
+      {/* コメント */}
+      {post.replyComments.length ? (
+        <Link href=''>
+          <p className='cursor-pointer text-secondary'>
+            {post.replyComments.length}件の返信
+          </p>
+        </Link>
+      ) : (
+        ''
+      )}
     </article>
   )
 }

--- a/src/components/post/Item/PostItemComment.tsx
+++ b/src/components/post/Item/PostItemComment.tsx
@@ -10,7 +10,7 @@ export const PostItemComment: FC<Props> = ({ comment }) => {
   const [isOpenComment, setIsOpenComment] = useState(false)
 
   // 要素の高さを取得
-  const hasElementMoreThan3Lines = useMemo(() => height > 80, [height])
+  const hasElementMoreThan3Lines = useMemo(() => height > 60, [height])
 
   const showSeeMore = useMemo(
     () => hasElementMoreThan3Lines && !isOpenComment,
@@ -23,14 +23,14 @@ export const PostItemComment: FC<Props> = ({ comment }) => {
           hasElementMoreThan3Lines && setIsOpenComment(!isOpenComment)
         }
         className={`${
-          !isOpenComment && 'h-70px'
+          !isOpenComment && 'h-50px'
         } overflow-hidden whitespace-pre-wrap group relative`}
       >
         <div ref={ref} className='h-auto'>
           {comment}
         </div>
         <div
-          className={`bg-primary-light bg-opacity-70 text-center w-full py-2 top-30px absolute ${
+          className={`bg-primary-light bg-opacity-80 text-center w-full py-1 top-20px absolute ${
             showSeeMore
               ? 'visible sm:invisible sm:group-hover:visible'
               : 'invisible'

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -17,7 +17,6 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
       ? post.metaInfo.image
       : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
   }, [post.metaInfo.image])
-  console.log(displayURL)
 
   return (
     <>

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -10,22 +10,24 @@ type Props = {
 export const PostLinkCard: FC<Props> = ({ post }) => {
   // ドメインによって、表示するURLを変える
   const displayURL = useMemo(() => {
-    return ['qiita-user', 'res.cloudinary', 'data:image/png;base64'].some((v) =>
+    if (!post.metaInfo.image) return ''
+    return ['qiita-user', 'res.cloudinary', 'data:image/png;base64'].some(v =>
       post.metaInfo.image?.includes(v),
     )
       ? post.metaInfo.image
       : `https://res.cloudinary.com/demo/image/fetch/${post.metaInfo.image}`
   }, [post.metaInfo.image])
+  console.log(displayURL)
 
   return (
     <>
-      <figure className='border-2 rounded-10px mt-2 duration-300 group hover:bg-gray-100 '>
+      <figure className='border-2 rounded-10px mt-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
         <Link href={post.url}>
           <a target='_blank'>
-            <div className='flex rounded-t-10px h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
-              {post.metaInfo.image ? (
+            <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
+              {displayURL ? (
                 <Image
-                  src={displayURL || ''}
+                  src={displayURL}
                   alt=''
                   className='bg-gray-100 rounded-10px transform duration-300 group-hover:scale-110'
                   width={430}
@@ -33,11 +35,12 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
                   objectFit='contain'
                 />
               ) : (
-                <div className='flex h-full bg-gray-300 rounded-t-10px text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
+                <div className='flex h-full bg-gray-300 text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
                   No image
                 </div>
               )}
             </div>
+
             <figcaption className='p-2'>
               <p className='text-13px text-gray-500'>
                 {post.url.split('//')[1].split('/')[0]}

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -122,7 +122,7 @@ export const PostMenuButton: FC<Props> = ({
             {(isOpenFolder || isOpenFolderList) && (
               <div
                 className={`shadow-md shadow-primary-light right-80px absolute sm:right-80px  ${
-                  user?.id !== post.userId ? 'top-40px' : 'top-120px'
+                  user?.id !== post.userId ? 'top-44px' : 'top-120px'
                 }`}
                 onMouseEnter={() => setIsOpenFolderList(true)}
                 onMouseLeave={() => setIsOpenFolderList(false)}

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -122,7 +122,7 @@ export const PostMenuButton: FC<Props> = ({
             {(isOpenFolder || isOpenFolderList) && (
               <div
                 className={`shadow-md shadow-primary-light right-80px absolute sm:right-80px  ${
-                  user?.id !== post.userId ? 'top-44px' : 'top-120px'
+                  user?.id !== post.userId ? 'top-44px' : 'top-124px'
                 }`}
                 onMouseEnter={() => setIsOpenFolderList(true)}
                 onMouseLeave={() => setIsOpenFolderList(false)}

--- a/src/components/post/Item/PostMenuButton.tsx
+++ b/src/components/post/Item/PostMenuButton.tsx
@@ -49,7 +49,7 @@ export const PostMenuButton: FC<Props> = ({
           />
 
           {/* モーダル */}
-          <div className='top-0 right-40px z-2 absolute sm:top-0 '>
+          <div className='top-0 right-40px z-1 absolute sm:top-0 '>
             <div className='bg-base border border-primary cursor-pointer rounded-10px shadow-lg shadow-primary-light transform w-170px overflow-hidden sm:w-150px'>
               {user?.id === post.userId && (
                 <>

--- a/src/components/shares/Modal.tsx
+++ b/src/components/shares/Modal.tsx
@@ -20,7 +20,7 @@ export const Modal: FC<Props> = ({ open, onClose, title, children }) => {
             />
 
             <Dialog.Panel className='transform top-[50%] left-[50%] z-2 translate-x-[-50%] translate-y-[-50%] fixed'>
-              <div className='bg-white bg-opacity-90 rounded-10px shadow-2xl w-300px '>
+              <div className='bg-white bg-opacity-97 rounded-10px shadow-2xl w-300px '>
                 <Dialog.Title className='font-bold text-center text-xl px-2 pt-4'>
                   {title}
                 </Dialog.Title>

--- a/src/components/shares/Modal.tsx
+++ b/src/components/shares/Modal.tsx
@@ -15,11 +15,11 @@ export const Modal: FC<Props> = ({ open, onClose, title, children }) => {
         <>
           <Dialog open={open} onClose={onClose}>
             <div
-              className='h-screen bg-black/30 w-screen top-0 left-0 z-10 fixed'
+              className='h-screen bg-black/30 w-screen top-0 left-0 z-2 fixed'
               aria-hidden='true'
             />
 
-            <Dialog.Panel className='transform top-[50%] left-[50%] z-100 translate-x-[-50%] translate-y-[-50%] fixed'>
+            <Dialog.Panel className='transform top-[50%] left-[50%] z-2 translate-x-[-50%] translate-y-[-50%] fixed'>
               <div className='bg-white bg-opacity-90 rounded-10px shadow-2xl w-300px '>
                 <Dialog.Title className='font-bold text-center text-xl px-2 pt-4'>
                   {title}

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -30,7 +30,9 @@ const Bookmark: NextPage = () => {
       <Layout>
         <div className='flex ml-4 justify-between'>
           <h1 className='font-bold text-2xl'>ブックマーク</h1>
-          <CreateFolderButton />
+          <div>
+            <CreateFolderButton />
+          </div>
         </div>
         <div className='mx-auto mt-20 w-300px'>
           <p>1. フォルダを作成してみよう！</p>

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -23,7 +23,7 @@ const Bookmark: NextPage = () => {
   const { data: bookmarkPosts } = useGetApi<BookmarkPosts>(
     `/folders/${folders && folders[selectedFolderIndex]?.id}`,
   )
-
+  console.log(bookmarkPosts)
   // フォルダが無い
   if (!folders?.length) {
     return (

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -52,7 +52,7 @@ const Bookmark: NextPage = () => {
 
       <div className='sm:(flex gap-3 items-start) '>
         {/* 自分のフォルダ一覧 */}
-        <div className='bg-base pl-4 top-0px z-10 sticky sm:top-100px'>
+        <div className='bg-base pl-4 top-0px z-2 sticky sm:top-100px'>
           <div className='mt-4 w-190px hidden sm:block'>
             <CreateFolderButton />
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,6 @@ import { deleteApi, postApi, putApi } from 'utils/api'
 
 const Home: NextPage = () => {
   const { data: posts, error } = useGetApi<Post[]>('/posts')
-  console.log(posts)
 
   const addReplyComment = useCallback(async () => {
     try {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import Head from 'next/head'
 import { useCallback } from 'react'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
-import { Button } from 'components/shares/button'
 import { useGetApi } from 'hooks/useApi'
 import { Post } from 'types/post'
 import { deleteApi, postApi, putApi } from 'utils/api'
@@ -16,9 +15,8 @@ const Home: NextPage = () => {
   const addReplyComment = useCallback(async () => {
     try {
       const res = await postApi('/reply_comments', {
-        userId: 1,
-        postId: 2,
-        body: '222コメントです',
+        postId: 3,
+        body: 'コメントです',
       })
       console.log(res)
     } catch (e) {
@@ -50,15 +48,15 @@ const Home: NextPage = () => {
         <title>SharePos 投稿一覧ページ</title>
       </Head>
       <Layout>
-        <Button onClick={addReplyComment}>追加</Button>
+        {/* <Button onClick={addReplyComment}>追加</Button>
         <Button onClick={() => updateReplyComment(13)}>更新</Button>
-        <Button onClick={() => deleteReplyComment(15)}>削除</Button>
+        <Button onClick={() => deleteReplyComment(15)}>削除</Button> */}
 
         {posts && (
           <div className='mt-4'>
             <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'>
-              {posts.map(post => (
-                <div key={post.id} className='mb-1'>
+              {posts.map((post, i) => (
+                <div key={i} className='mb-1'>
                   <PostItem post={post} />
                 </div>
               ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,21 +1,48 @@
 import { NextPage } from 'next'
 import Head from 'next/head'
-import { useState } from 'react'
 
+import { useCallback } from 'react'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
+import { Button } from 'components/shares/button'
 import { useGetApi } from 'hooks/useApi'
-import { useCookies } from 'stores/useCookies'
 import { Post } from 'types/post'
-import { deleteApi } from 'utils/api'
+import { deleteApi, postApi, putApi } from 'utils/api'
 
 const Home: NextPage = () => {
   const { data: posts, error } = useGetApi<Post[]>('/posts')
-  const { cookies, set } = useCookies('token')
-  if (false) {
-    deleteApi('/posts/delete_all')
-  }
-  const [stars, setStars] = useState(1)
+  console.log(posts)
+
+  const addReplyComment = useCallback(async () => {
+    try {
+      const res = await postApi('/reply_comments', {
+        userId: 1,
+        postId: 2,
+        body: '222コメントです',
+      })
+      console.log(res)
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
+  const updateReplyComment = useCallback(async (id: number) => {
+    try {
+      const res = await putApi(`/reply_comments/${id}`, {
+        body: 'update',
+      })
+      console.log(res)
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
+  const deleteReplyComment = useCallback(async (id: number) => {
+    try {
+      const res = await deleteApi(`/reply_comments/${id}`)
+      console.log(res)
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
 
   return (
     <>
@@ -23,10 +50,10 @@ const Home: NextPage = () => {
         <title>SharePos 投稿一覧ページ</title>
       </Head>
       <Layout>
-        {/* <PostStars
-          evaluation={stars}
-          onClick={(newStar) => setStars(newStar)}
-        /> */}
+        <Button onClick={addReplyComment}>追加</Button>
+        <Button onClick={() => updateReplyComment(13)}>更新</Button>
+        <Button onClick={() => deleteReplyComment(15)}>削除</Button>
+
         {posts && (
           <div className='mt-4'>
             <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'>

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -15,6 +15,14 @@ export type Post = {
     image: string | undefined
     title: string
   }
+  replyComments: {
+    id: number
+    body: string
+    user: {
+      id: number
+      username: string
+    }
+  }[]
   bookmark?: {
     id: string
   }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,8 +5,8 @@ import { toCamelCaseObj } from './toCamelCaseObj'
 import { Res } from 'types/response'
 
 // export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
-export const BASE_URL = 'http://localhost:3001/api/v1'
-// export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL2
+// export const BASE_URL = 'http://localhost:3001/api/v1'
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL2
 
 type Method = 'GET' | 'POST' | 'PUT' | 'DELETE'
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,8 +5,8 @@ import { toCamelCaseObj } from './toCamelCaseObj'
 import { Res } from 'types/response'
 
 // export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
-// export const BASE_URL = 'http://localhost:3001/api/v1'
-export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL2
+export const BASE_URL = 'http://localhost:3001/api/v1'
+// export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL2
 
 type Method = 'GET' | 'POST' | 'PUT' | 'DELETE'
 


### PR DESCRIPTION
## 詳細
- Postデータのreply_commentsの数を、PostItemの下部に追加
- z-indexを、1,2だけにする
- ブックマークページのレイアウトの崩れを修正
- PostItemのLinkCardの、枠が余るのを修正
- FolderListで、フォルダ数が0だと、画面に0を表示するのを修正
## 見て欲しいファイル
- PostItem
- PostLinkCard
- type/post

## 動作確認

- 返信数表示
![image](https://user-images.githubusercontent.com/88410576/202824934-a3f062a0-be08-42eb-9935-29cbfc7988c3.png)


- ブックマークページのバグ
before
![image](https://user-images.githubusercontent.com/88410576/202824981-c5a06ba8-ab20-4ca7-9ea9-1dd7dc2de481.png)

after
![image](https://user-images.githubusercontent.com/88410576/202824995-fed6435f-7199-4e34-911f-06245ed2a8e0.png)

- FolderListで、フォルダ数が0だと、画面に0を表示するのを修正
before
![image](https://user-images.githubusercontent.com/88410576/202825988-811163a4-2228-4843-8b02-1b436a13d2e2.png)

after
![image](https://user-images.githubusercontent.com/88410576/202826031-baeabc5c-dbf1-4aeb-8c69-b76f011e5c56.png)








