### PR TITLE
fix: Post編集時のPostItemの横幅を最大にする

### DIFF
--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -78,8 +78,11 @@ export const PostForm: FC<Props> = ({
           </label>
 
           <div className='min-h-[50px] leading-1.4rem relative'>
-            <div className='py-3 px-2 invisible whitespace-pre-wrap break-words'>
-              {formParams.comment}
+            <div
+              className='py-3 invisible whitespace-pre-wrap'
+              aria-hidden='true'
+            >
+              この文字で　編集時の　PostItemの横幅を　最大に　保っている
             </div>
             <textarea
               name='comment'


### PR DESCRIPTION
## 関連 Issue

- #113 



## 動作確認
before

![206823702-ba98c300-bb8a-4a32-936c-2c16a91954b5](https://user-images.githubusercontent.com/88410576/206907955-c4a63c34-43cb-4523-b691-ed04fa29417a.png)

after

![image](https://user-images.githubusercontent.com/88410576/206908032-c8cd2288-8bfb-49d0-bc11-2fe66afda5b2.png)


