### PR TITLE
Feature/post list columns to bt responsize

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,7 +11,8 @@ export const Layout: FC<Props> = ({ children }) => {
     <div className='bg-primary-light min-h-screen'>
       <Header />
       <main>
-        <div className='mx-auto max-w-1150px px-4 pt-50px pb-150px'>
+        {/* <div className='mx-auto max-w-1150px px-4 pt-50px pb-150px'> */}
+        <div className='mx-auto max-w-1000px px-4 pt-50px pb-150px'>
           {children}
         </div>
       </main>

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -27,7 +27,7 @@ export const Header: FC = () => {
         !isShow && 'translate-y-[-100%]'
       } sm:translate-y-0 sticky duration-300`}
     >
-      <nav className='flex mx-auto max-w-1150px px-4 items-center justify-between'>
+      <nav className='flex mx-auto max-w-1000px px-4 items-center justify-between'>
         <Link href='/'>
           <h1 className='cursor-pointer font-cantoreOne mt-0 text-primary-dark mb-1 text-4xl'>
             SharePos

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -28,7 +28,8 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
   const { removeBookmark } = useRemoveBookmark(bookmarkFolderId, post)
 
   return (
-    <article className='bg-white rounded-lg shadow-xl max-w-460px p-4 w-100% sm:w-291px'>
+    // <article className='bg-white rounded-lg shadow-xl max-w-460px p-4 w-100% sm:w-291px'>
+    <article className='bg-white rounded-lg shadow-xl max-w-460px p-4 w-100%'>
       <div className='flex justify-between items-center'>
         <Link href={`/users/${post.user.id}`}>
           <div className='cursor-pointer flex font-bold text-20px gap-2 items-center'>

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -51,6 +51,9 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
 
       {/* 編集中ならtextarea それ以外は コメント表示 */}
       <div className='mt-3'>
+        {/* <div className='h-0 invisible'>
+              Imageを next/image なら横幅を保つために必要
+            </div>　*/}
         {isEditing ? (
           <div className='mx-1'>
             <PostForm

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -37,7 +37,7 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
                 alt=''
                 className='bg-gray-100 rounded-10px transform duration-300 group-hover:scale-110'
                 width={430}
-                height={20000}
+                height={2000}
                 // fill
                 objectFit='contain'
               />

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/legacy/image'
+// import Image from 'next/image'
 import { FC, useMemo } from 'react'
 import { Post } from 'types/post'
 
@@ -21,21 +22,32 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
     <>
       <figure className='border-2 rounded-10px mt-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
         <a href={post.url} target='_blank' rel='noreferrer'>
-          {/* <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'> */}
-          {/* <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-20vw md:(h-13vw max-h-140px) '> */}
-          {/* <div className='flex h-40vw max-h-220px overflow-hidden items-center sm:h-20vw md:(h-13vw max-h-140px) '> */}
-          <div className='flex h-40vw max-h-220px overflow-hidden items-center sm:h-19.5vw md:h-[20vw] lg:(h-13vw max-h-135px) '>
+          {/* <div className='flex h-40vw max-h-220px overflow-hidden items-center sm:h-19.5vw md:h-[20vw] lg:(h-13vw max-h-135px) '> */}
+          {/* <div className={`${post.bookmark?.id? 'sm:h-[20vw] md:(h-26vw) lg:(max-h-155px)': 'sm:h-19.6vw md:h-21vw lg:h-136px'} w-full relative h-42vw max-h-225px`}> */}
+          <div
+            className={`flex h-40vw max-h-220px overflow-hidden items-center ${
+              post.bookmark?.id
+                ? 'sm:h-26vw md:(h-26vw) lg:(max-h-155px)'
+                : 'sm:h-19.5vw md:h-20vw lg:(h-13vw max-h-135px)'
+            }`}
+          >
             {displayURL ? (
               <Image
                 src={displayURL}
                 alt=''
                 className='bg-gray-100 rounded-10px transform duration-300 group-hover:scale-110'
                 width={430}
-                height={2000}
+                height={20000}
+                // fill
                 objectFit='contain'
               />
             ) : (
-              <div className='flex h-full bg-gray-300 text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
+              <div
+                className='flex h-full bg-gray-300 text-mono
+                          w-full max-h-225px transform text-30px duration-300 overflow-hidden
+                          items-center justify-center group-hover:scale-110
+                          '
+              >
                 No image
               </div>
             )}

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -22,7 +22,9 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
       <figure className='border-2 rounded-10px mt-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
         <a href={post.url} target='_blank' rel='noreferrer'>
           {/* <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'> */}
-          <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-20vw md:(h-13vw max-h-140px) '>
+          {/* <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-20vw md:(h-13vw max-h-140px) '> */}
+          {/* <div className='flex h-40vw max-h-220px overflow-hidden items-center sm:h-20vw md:(h-13vw max-h-140px) '> */}
+          <div className='flex h-40vw max-h-220px overflow-hidden items-center sm:h-19.5vw md:h-[20vw] lg:(h-13vw max-h-135px) '>
             {displayURL ? (
               <Image
                 src={displayURL}

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -21,7 +21,8 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
     <>
       <figure className='border-2 rounded-10px mt-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
         <a href={post.url} target='_blank' rel='noreferrer'>
-          <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
+          {/* <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'> */}
+          <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-20vw md:(h-13vw max-h-140px) '>
             {displayURL ? (
               <Image
                 src={displayURL}

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -78,11 +78,11 @@ export const PostForm: FC<Props> = ({
           </label>
 
           <div className='min-h-[50px] leading-1.4rem relative'>
-            <div
-              className='py-3 invisible whitespace-pre-wrap'
-              aria-hidden='true'
-            >
-              この文字で　編集時の　PostItemの横幅を　最大に　保っている
+            <div className='py-3 whitespace-pre-wrap' aria-hidden='true'>
+              {/* <span className='sm:hidden'>
+                この文字で　編集時の　 PostItemの横幅
+              </span> */}
+              {formParams.comment}
             </div>
             <textarea
               name='comment'

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -77,11 +77,8 @@ export const PostForm: FC<Props> = ({
             コメント
           </label>
 
-          <div className='min-h-[50px] leading-1.4rem relative'>
+          <div className='min-h-50px leading-1.4rem relative'>
             <div className='py-3 whitespace-pre-wrap' aria-hidden='true'>
-              {/* <span className='sm:hidden'>
-                この文字で　編集時の　 PostItemの横幅
-              </span> */}
               {formParams.comment}
             </div>
             <textarea

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -52,7 +52,7 @@ const Bookmark: NextPage = () => {
         </div>
       </div>
 
-      <div className='sm:(flex gap-3 items-start) '>
+      <div className='sm:(flex items-start) '>
         {/* 自分のフォルダ一覧 */}
         <div className='bg-primary-light mx-[-16px] pb-[10px] pl-4 top-0px z-2 sticky sm:(z-1 mx-0 top-100px) '>
           <div className='mt-4 hidden sm:block'>
@@ -65,8 +65,9 @@ const Bookmark: NextPage = () => {
 
         {/* 選択しているフォルダの記事一覧 */}
         {bookmarkPosts?.posts.length && folders ? (
-          <div className='mt-4 w-full'>
-            <div className='grid gap-6 justify-center items-start sm:(gap-x-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
+          <div className='mt-4 w-full sm:(mr-4 ml-8) '>
+            <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
+              {/* <div className='grid gap-6 justify-center items-start md:grid-cols-2'> */}
               {bookmarkPosts.posts.map((post, index) => (
                 <PostItem
                   key={index}

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -65,9 +65,9 @@ const Bookmark: NextPage = () => {
 
         {/* 選択しているフォルダの記事一覧 */}
         {bookmarkPosts?.posts.length && folders ? (
-          <div className='mt-4 w-full sm:(mr-4 ml-8) '>
-            <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
-              {/* <div className='grid gap-6 justify-center items-start md:grid-cols-2'> */}
+          <div className='mt-10 sm:(mr-4 ml-8) '>
+            {/* <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '> */}
+            <div className='grid gap-6 items-start justify-center lg:grid-cols-2'>
               {bookmarkPosts.posts.map((post, index) => (
                 <PostItem
                   key={index}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -52,7 +52,8 @@ const Home: NextPage = () => {
 
         {posts && (
           <div className='mt-4'>
-            <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'>
+            {/* <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'> */}
+            <div className='grid gap-6 justify-center items-start sm:grid-cols-2 md:grid-cols-3'>
               {posts.map((post, i) => (
                 <div key={i} className='mb-1'>
                   <PostItem post={post} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,7 +53,9 @@ const Home: NextPage = () => {
         {posts && (
           <div className='mt-4'>
             {/* <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'> */}
-            <div className='grid gap-6 justify-center items-start sm:grid-cols-2 md:grid-cols-3'>
+            {/* <div className='grid gap-6 justify-center items-start sm:grid-cols-2 md:grid-cols-3'> */}
+            {/* <div className='mt-10 grid gap-6 items-start justify-center sm:mx-4 sm:grid-cols-2 lg:grid-cols-3'> */}
+            <div className='mt-10 grid gap-6 items-start justify-center sm:mx-4 sm:grid-cols-2 lg:grid-cols-3'>
               {posts.map((post, i) => (
                 <div key={i} className='mb-1'>
                   <PostItem post={post} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -51,11 +51,9 @@ const Home: NextPage = () => {
         <Button onClick={() => deleteReplyComment(15)}>削除</Button> */}
 
         {posts && (
-          <div className='mt-4'>
+          <div className='mt-4 sm:mx-4'>
             {/* <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'> */}
-            {/* <div className='grid gap-6 justify-center items-start sm:grid-cols-2 md:grid-cols-3'> */}
-            {/* <div className='mt-10 grid gap-6 items-start justify-center sm:mx-4 sm:grid-cols-2 lg:grid-cols-3'> */}
-            <div className='mt-10 grid gap-6 items-start justify-center sm:mx-4 sm:grid-cols-2 lg:grid-cols-3'>
+            <div className='mt-10 grid gap-6 items-start justify-center sm:grid-cols-2 lg:grid-cols-3'>
               {posts.map((post, i) => (
                 <div key={i} className='mb-1'>
                   <PostItem post={post} />

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -98,8 +98,9 @@ const User: NextPage = () => {
         </div>
 
         {userPosts?.posts.length ? (
-          <div className='flex flex-wrap mt-10 gap-4 justify-center items-start sm:justify-start'>
-            {/* <div className='mt-4 grid gap-4 grid-cols-[repeat(auto-fill,minmax(291px,auto))] justify-center items-start'> */}
+          // <div className='flex flex-wrap mt-10 gap-4 justify-center items-start sm:justify-start'>
+          // <div className='mt-4 grid gap-6 grid-cols-[repeat(auto-fill,minmax(291px,auto))] justify-center items-start sm:mx-4'>
+          <div className='mt-10 grid gap-6 items-start justify-center sm:mx-4 sm:grid-cols-2 lg:grid-cols-3'>
             {userPosts.posts.map(
               post =>
                 selectedPublished === post.published && (

--- a/windi.config.js
+++ b/windi.config.js
@@ -8,6 +8,13 @@ export default defineConfig({
   },
   theme: {
     extend: {
+      // screens: {
+      //   sm: '640px',
+      //   md: '768px',
+      //   lg: '1024px',
+      //   xl: '1280px',
+      //   '2xl': '1536px',
+      // },
       colors: {
         primary: {
           light: primary.light,

--- a/windi.config.js
+++ b/windi.config.js
@@ -8,13 +8,6 @@ export default defineConfig({
   },
   theme: {
     extend: {
-      // screens: {
-      //   sm: '640px',
-      //   md: '768px',
-      //   lg: '1024px',
-      //   xl: '1280px',
-      //   '2xl': '1536px',
-      // },
       colors: {
         primary: {
           light: primary.light,


### PR DESCRIPTION
## 関連 Issue
- #108
- #126 

## 詳細
- Layoutのmax-widthを1000pxに
- PostItemを画面幅で、均等にする
  - ~640px
    - 1カラム　indexページ、ユーザーページ、ブックマークページ
  - 640px~
    - 2カラム　indexページ、ユーザーページ
  - 1024px~
    - 2カラム　ブックマークページ
    - 3カラム　indexページ、ユーザーページ
- PostLinkCardのImageは、やっぱりnext/legacy/imageを使う
- PostLinkCardのheight, widthを、画面幅でゴリゴリに変える

## 良くない点
ブックマークページ(Bookmark.tsx)は、サイドバーがあってカラム数が他のページと変わる
ブックマークページの時、PostLinkCardをブックマークページのカラムに対応させている
post.bookmark?.id ? 

## 動作確認

indexページ
![chrome-capture-2022-11-15](https://user-images.githubusercontent.com/88410576/207805185-4fbcf2df-1f42-4ff1-84ec-753a7cb90775.gif)

ブックマークページ
![chrome-capture-2022-11-15 (1)](https://user-images.githubusercontent.com/88410576/207806735-9ed0d5c7-1b95-4fb9-a02b-0ad9d6d8f2ed.gif)


ユーザーページ
![chrome-capture-2022-11-15 (2)](https://user-images.githubusercontent.com/88410576/207807095-283625d2-6f98-4d7d-bb8f-496449ab7e0c.gif)
