### PR TITLE
fix: textarea改行すると、高さも増える

### DIFF
--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -83,6 +83,7 @@ export const PostForm: FC<Props> = ({
               aria-hidden='true'
             >
               この文字で　編集時の　PostItemの横幅を　最大に　保っている
+              {formParams.comment}
             </div>
             <textarea
               name='comment'


### PR DESCRIPTION
## 詳細
- textareaで改行で高さが変わるようにする
- PostItemのwidthが狭いと、textareaの高さが広がってしまうけどしょうがない

## 動作確認
before
改行しても、高さ変わらない
![image](https://user-images.githubusercontent.com/88410576/209740691-3b572abc-e31a-4da6-ad6a-7d859517d16f.png)


after
![image](https://user-images.githubusercontent.com/88410576/209740724-59547f02-db9c-44cf-8a08-6fd8588a55df.png)

でも、Postitemのwidthが狭いと、余分な高さが増える
![image](https://user-images.githubusercontent.com/88410576/209740787-1cc6cf49-5fb6-40b4-9582-ec8431c68057.png)
