### PR TITLE
fix: 一日経つ前に1日前になるのを修正

### DIFF
--- a/src/utils/calcHowManyDaysAgo.ts
+++ b/src/utils/calcHowManyDaysAgo.ts
@@ -17,10 +17,10 @@ export const calcHowManyDaysAgo = (date: string) => {
   if (nowD - targetD > 31) {
     return `${~~((nowD - targetD) / 31)}ヶ月前`
   }
-  if (nowD !== targetD) {
+  if (nowH - targetH > 24) {
     return `${nowD - targetD}日前`
   }
-  if (nowH !== targetH) {
+  if (nowM - targetM > 60) {
     return `${nowH - targetH}時間前`
   }
   return `${nowM - targetM}分前`


### PR DESCRIPTION
## 詳細
- 前のPRと同じで、1日もミリ秒だと誤差でずれてしまう
- 一日経つ前に1日前になるのを修正

## 動作確認
before
![image](https://user-images.githubusercontent.com/88410576/209762890-12195ef3-8af4-48a3-8b14-f5a6afa5e7b2.png)

after
![image](https://user-images.githubusercontent.com/88410576/209762811-4d984f09-8064-4d87-9b6e-8b1ad53ecb4d.png)
