### PR TITLE
Fix/PostFormのラジオボタンの細かい修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
   "[markdown]": {
     "files.trimTrailingWhitespace": false
   },
-  "windicss.sortOnSave": true
+  "windicss.sortOnSave": true,
+  "editor.minimap.enabled": false, // 右のマップ消す
+  "explorer.compactFolders": false, // フォルダの省略を防ぐ
+  "search.smartCase": true // 検索候補を出しやすく
 }

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -19,7 +19,7 @@ export const PostForm: FC<Props> = ({
     comment: '',
     url: '',
     evaluation: 1,
-    published: false,
+    published: true,
   },
   submitButtonText = 'シェアする',
 }) => {
@@ -116,9 +116,9 @@ export const PostForm: FC<Props> = ({
                 })
               }
             >
-              <div className=' font-bold text-white text-md transform top-[2px] left-[5px] absolute'>
+              <div className='font-bold text-white text-md transform top-[2px] left-[5px] absolute'>
                 公開
-                <span className='transform scale-x-80 inline-block'>
+                <span className='ml-3px transform scale-x-80 inline-block'>
                   非公開
                 </span>
               </div>
@@ -126,7 +126,10 @@ export const PostForm: FC<Props> = ({
                 className={`bg-white h-20px rounded-full top-4px ${
                   formParams.published ? 'left-40px w-46px' : 'left-3px w-38px'
                 } duration-150 absolute`}
-              ></div>
+              >
+                <input type='radio' name='a' className='opacity-0' />
+                <input type='radio' name='a' className='opacity-0' />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 詳細
- 公開・非公開を、PostFormのコメントからタブで移動できるように
- 公開・非公開の文字間隔を広げる
- 記事の初期値を、公開に
- settings.jsonに追加
  - 右のミニマップ消す
  - エクスプローラーのフォルダの省略を防ぐ
  - 小文字で大文字の検索候補を出しやすく
