### PR TITLE
Feature/add theme rounded to windi config

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -34,7 +34,7 @@ export const LoginForm: FC<Props> = ({ onSubmit }) => {
             placeholder='example@example.com'
             required
             onChange={v => setEmail(v.target.value)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
           <AiOutlineMailIcon className='top-33px left-270px absolute' />
         </div>
@@ -49,7 +49,7 @@ export const LoginForm: FC<Props> = ({ onSubmit }) => {
             placeholder='password'
             required
             onChange={v => setPassword(v.target.value)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
           <RiLockPasswordLineIcon className='top-33px left-270px absolute' />
         </div>

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -49,7 +49,7 @@ export const SignUpForm: FC<Props> = ({ onSubmit }) => {
             required
             name='username'
             onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
           <AiOutlineUserIcon className='top-33px left-270px absolute' />
         </div>
@@ -65,7 +65,7 @@ export const SignUpForm: FC<Props> = ({ onSubmit }) => {
             required
             name='email'
             onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
           <AiOutlineMailIcon className='top-33px left-270px absolute' />
         </div>
@@ -82,7 +82,7 @@ export const SignUpForm: FC<Props> = ({ onSubmit }) => {
             minLength={6}
             name='password'
             onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
           <RiLockPasswordLineIcon className='top-33px left-270px absolute' />
         </div>
@@ -102,7 +102,7 @@ export const SignUpForm: FC<Props> = ({ onSubmit }) => {
             placeholder='password'
             name='passwordConfirmation'
             onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
           <RiLockPasswordLineIcon className='top-33px left-270px absolute' />
         </div>

--- a/src/components/bookmark/CreateFolderButton.tsx
+++ b/src/components/bookmark/CreateFolderButton.tsx
@@ -41,7 +41,7 @@ export const CreateFolderButton: FC<Props> = ({ radius = 'md' }) => {
               required
               value={name}
               onChange={e => setName(e.target.value)}
-              className='border outline-none rounded-3px w-full p-1 ring-gray-300 duration-300 focus:ring-1'
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
             />
           </div>
           <button

--- a/src/components/bookmark/FolderEditModal.tsx
+++ b/src/components/bookmark/FolderEditModal.tsx
@@ -38,7 +38,6 @@ export const FolderEditModal: FC<Props> = ({
           <div className='flex px-4 gap-2 justify-center items-center'>
             <input
               type='text'
-              // className='border outline-none rounded-3px w-full p-1 ring-gray-300 duration-300 focus:ring-1'
               className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
               maxLength={15}
               required

--- a/src/components/bookmark/FolderEditModal.tsx
+++ b/src/components/bookmark/FolderEditModal.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from 'react'
+import { IoTrashOutline as IoTrashOutlineIcon } from 'react-icons/io5'
 import { Modal } from 'components/shares/Modal'
 import { Folder } from 'types/bookmark'
 
@@ -34,21 +35,21 @@ export const FolderEditModal: FC<Props> = ({
             await onUpdateFolder(editFolderName)
           }}
         >
-          <div className='flex px-4 justify-center items-center'>
+          <div className='flex px-4 gap-2 justify-center items-center'>
             <input
               type='text'
-              className='border outline-none rounded-3px w-full p-1 ring-gray-300 duration-300 focus:ring-1'
+              // className='border outline-none rounded-3px w-full p-1 ring-gray-300 duration-300 focus:ring-1'
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
               maxLength={15}
               required
               value={editFolderName}
               onChange={e => setEditFolderName(e.target.value)}
             />
-            <div
-              className='bg-danger-dark cursor-pointer font-bold rounded-3px text-white ml-1 py-1 px-2.5'
+
+            <IoTrashOutlineIcon
               onClick={() => setIsShowDeleteMessage(true)}
-            >
-              ✕
-            </div>
+              className='bg-danger-dark border-danger-dark rounded-md cursor-pointer border-2 h-10 text-white p-1.5 w-12'
+            />
           </div>
 
           <div className='flex justify-between'>

--- a/src/components/post/Item/FolderList.tsx
+++ b/src/components/post/Item/FolderList.tsx
@@ -30,7 +30,7 @@ export const FolderList: FC<Props> = ({
         `}
       </style>
 
-      <div className='bg-white rounded-10px shadow-outline w-160px overflow-hidden'>
+      <div className='bg-white rounded-md shadow-outline w-160px overflow-hidden'>
         <CreateFolderButton radius='xs' />
 
         <div className='max-h-250px overflow-y-scroll scroll-bar-none'>

--- a/src/components/post/Item/PostItem.tsx
+++ b/src/components/post/Item/PostItem.tsx
@@ -28,7 +28,7 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
   const { removeBookmark } = useRemoveBookmark(bookmarkFolderId, post)
 
   return (
-    <article className='bg-white rounded-lg shadow-xl max-w-460px p-4 w-100% sm:w-291px'>
+    <article className='bg-white rounded-md shadow-xl max-w-460px p-4 w-100% sm:w-291px'>
       <div className='flex justify-between items-center'>
         <Link href={`/users/${post.user.id}`}>
           <div className='cursor-pointer flex font-bold text-20px gap-2 items-center'>

--- a/src/components/post/Item/PostLinkCard.tsx
+++ b/src/components/post/Item/PostLinkCard.tsx
@@ -19,14 +19,14 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
 
   return (
     <>
-      <figure className='border-2 rounded-10px mt-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
+      <figure className='rounded-md border-2 mt-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
         <a href={post.url} target='_blank' rel='noreferrer'>
           <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
             {displayURL ? (
               <Image
                 src={displayURL}
                 alt=''
-                className='bg-gray-100 rounded-10px transform duration-300 group-hover:scale-110'
+                className='bg-gray-100 transform duration-300 group-hover:scale-110'
                 width={430}
                 height={2000}
                 objectFit='contain'

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -64,7 +64,7 @@ export const PostForm: FC<Props> = ({
             required
             name='url'
             onChange={onChange}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-10px focus:ring-1'
+            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
           />
 
           <div className='flex justify-end'>
@@ -87,7 +87,7 @@ export const PostForm: FC<Props> = ({
             </div>
             <textarea
               name='comment'
-              className='border h-full outline-none ring-primary-dark w-full p-2 pr-9 top-0 left-0 duration-300 scroll-bar-none absolute focus:rounded-10px focus:ring-1'
+              className='border h-full outline-none ring-primary-dark w-full p-2 pr-9 top-0 left-0 duration-300 scroll-bar-none absolute focus:rounded-md focus:ring-1'
               value={formParams.comment}
               placeholder='この記事オススメ！'
               onChange={onChange}

--- a/src/components/shares/Avatar.tsx
+++ b/src/components/shares/Avatar.tsx
@@ -40,11 +40,11 @@ export const Avatar: FC<Props> = ({
   const radiusClass = useMemo(() => {
     switch (radius) {
       case 'sm':
-        return 'rounded-3px'
+        return 'rounded-sm'
       case 'md':
-        return 'rounded-7px'
+        return 'rounded-md'
       case 'lg':
-        return 'rounded-15px'
+        return 'rounded-lg'
       case 'xl':
         return 'rounded-full'
     }

--- a/src/components/shares/DropDownMenu.tsx
+++ b/src/components/shares/DropDownMenu.tsx
@@ -26,7 +26,7 @@ export const DropDownMenu: FC<Props> = ({
           {/* メニュー */}
           <div
             className={`z-1 absolute ${className}
-                        bg-white cursor-pointer rounded-3px shadow-outline w-160px overflow-hidden`}
+                        bg-white cursor-pointer rounded-sm shadow-outline w-160px overflow-hidden`}
           >
             {children}
           </div>

--- a/src/components/shares/Modal.tsx
+++ b/src/components/shares/Modal.tsx
@@ -20,7 +20,7 @@ export const Modal: FC<Props> = ({ open, onClose, title, children }) => {
             />
 
             <Dialog.Panel className='transform top-[50%] left-[50%] z-2 translate-x-[-50%] translate-y-[-50%] fixed'>
-              <div className='bg-white bg-opacity-97 rounded-10px shadow-2xl w-300px '>
+              <div className='bg-white bg-opacity-97 rounded-md shadow-2xl w-300px '>
                 <Dialog.Title className='font-bold text-center text-xl px-2 pt-4'>
                   {title}
                 </Dialog.Title>

--- a/src/components/shares/button/Button.tsx
+++ b/src/components/shares/button/Button.tsx
@@ -116,14 +116,12 @@ export const Button: FC<Props> = ({
 
   const RadiusClass = useMemo(() => {
     switch (radius) {
-      case 'xs':
-        return ''
       case 'sm':
-        return 'rounded-3px'
+        return 'rounded-sm'
       case 'md':
-        return 'rounded-7px'
+        return 'rounded-md'
       case 'lg':
-        return 'rounded-15px'
+        return 'rounded-lg'
       case 'xl':
         return 'rounded-full'
     }

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,3 +1,5 @@
+// color
+
 const base = {
   green: '#0b7e7f',
   lightGreen: '#dfecee',
@@ -28,3 +30,12 @@ export const secondary = {
   light: base.lightGray,
   dark: base.gray,
 } as const
+
+// rounded
+export const rounded = {
+  xs: '0x',
+  sm: '3px',
+  md: '7px',
+  lg: '15px',
+  xl: '100%',
+}

--- a/windi.config.js
+++ b/windi.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'windicss/helpers'
-import { accent, danger, primary, secondary } from './src/utils/theme'
+import { accent, danger, primary, rounded, secondary } from './src/utils/theme'
 
 export default defineConfig({
   extract: {
@@ -31,6 +31,11 @@ export default defineConfig({
       },
       boxShadow: {
         outline: '0 3px 12px -1px #04253f40',
+      },
+      borderRadius: {
+        sm: rounded.sm,
+        md: rounded.md,
+        lg: rounded.lg,
       },
     },
   },


### PR DESCRIPTION
## 関連 Issue

- #122 

## 詳細

- windi.configのthemeで、roundedを管理する
- 使っていたroundedをsm, md, lg, fullだけにする
- モーダルのフォルダ削除ボタンをアイコンにする

## 動作確認
少し丸みが無くなった
![image](https://user-images.githubusercontent.com/88410576/210955956-3a4f38d9-2015-4c2e-bd36-9c63dc3f78ca.png)

削除ボタンをアイコンに
![image](https://user-images.githubusercontent.com/88410576/210956040-e494cb6f-8c2b-47cd-a6bb-509721f012c4.png)
