### PR TITLE
SWRで再取得しない

### DIFF
--- a/src/components/post/Item/FolderList.tsx
+++ b/src/components/post/Item/FolderList.tsx
@@ -39,7 +39,6 @@ export const FolderList: FC<Props> = ({
               key={index}
               className='flex text-left w-full py-1 px-2 gap-1 items-center hover:bg-primary-light'
               onClick={async () => {
-                console.log('click! : ')
                 onClickFolderName?.()
                 await onAddBookmark?.(folder.id, post)
               }}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -15,6 +15,8 @@ export const useGetApi = <Data = any>(
 
   return useSWR<Data, HttpError>(`${url}${JSON.stringify(params)}`, fetcher, {
     revalidateOnReconnect: false,
+    revalidateIfStale: false, //古いデータがあっても自動的に再検証
+    revalidateOnFocus: false, //ウィンドウがフォーカスされると自動的に再有効化
     fallbackData,
   })
 }

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -4,19 +4,28 @@ import { fetchApi, HttpError } from '../utils/api'
 
 export const useGetApi = <Data = any>(
   url: string,
-  params?: Record<string, any>,
-  headers?: Record<string, string>,
-  fallbackData?: Data,
+  props?: {
+    params?: Record<string, any>
+    headers?: Record<string, string>
+    fallbackData?: Data
+    options: {
+      revalidateIfStale?: boolean
+    }
+  },
 ): SWRResponse<Data, HttpError> => {
   const fetcher = useCallback(
-    async () => await fetchApi<Data>(url, 'GET', params, headers),
-    [url, params, headers],
+    async () => await fetchApi<Data>(url, 'GET', props?.params, props?.headers),
+    [props?.headers, props?.params, url],
   )
 
-  return useSWR<Data, HttpError>(`${url}${JSON.stringify(params)}`, fetcher, {
-    revalidateOnReconnect: false,
-    revalidateIfStale: false, //古いデータがあっても自動的に再検証
-    revalidateOnFocus: false, //ウィンドウがフォーカスされると自動的に再有効化
-    fallbackData,
-  })
+  return useSWR<Data, HttpError>(
+    `${url}${JSON.stringify(props?.params)}`,
+    fetcher,
+    {
+      revalidateOnReconnect: false,
+      revalidateIfStale: props?.options?.revalidateIfStale,
+      revalidateOnFocus: false,
+      fallbackData: props?.fallbackData,
+    },
+  )
 }

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -7,7 +7,7 @@ import { postApi, HttpError, deleteApi } from 'utils/api'
 // SWRの再取得無いから、ブックマークが変更されない
 // 結論。ブックマークページだけ毎回取得する(SWRの再取得ありか、SSRする)
 export const useAddBookmark = () => {
-  const addBookmark = async (folderId: string, post: Post) => {
+  const addBookmark = useCallback(async (folderId: string, post: Post) => {
     try {
       const res = await postApi<Post>('/folders/bookmarks', {
         folderId,
@@ -19,7 +19,7 @@ export const useAddBookmark = () => {
         console.error(e.message)
       }
     }
-  }
+  }, [])
 
   return { addBookmark }
 }

--- a/src/hooks/useBookmark.ts
+++ b/src/hooks/useBookmark.ts
@@ -4,10 +4,12 @@ import { BookmarkPosts } from 'types/bookmark'
 import { Post } from 'types/post'
 import { postApi, HttpError, deleteApi } from 'utils/api'
 
+// SWRの再取得無いから、ブックマークが変更されない
+// 結論。ブックマークページだけ毎回取得する(SWRの再取得ありか、SSRする)
 export const useAddBookmark = () => {
-  const addBookmark = useCallback(async (folderId: string, post: Post) => {
+  const addBookmark = async (folderId: string, post: Post) => {
     try {
-      const res = await postApi('/folders/bookmarks', {
+      const res = await postApi<Post>('/folders/bookmarks', {
         folderId,
         postId: post.id,
       })
@@ -17,7 +19,7 @@ export const useAddBookmark = () => {
         console.error(e.message)
       }
     }
-  }, [])
+  }
 
   return { addBookmark }
 }
@@ -38,7 +40,7 @@ export const useRemoveBookmark = (folderId: string, post: Post) => {
         id: bookmarkPosts?.id,
         name: bookmarkPosts?.name,
         posts: bookmarkPosts?.posts.filter(
-          (v) => v.bookmark?.id !== post.bookmark?.id,
+          v => v.bookmark?.id !== post.bookmark?.id,
         ),
       }
       postsMutate(newBookmarkPosts, false)

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -21,9 +21,9 @@ export const useCreatePost = () => {
           return
         }
 
-        mutatePosts([...posts, newPost], false)
+        mutatePosts([newPost, ...posts], false)
         mutateMyPosts(
-          { user: myPosts.user, posts: [...myPosts.posts, newPost] },
+          { user: myPosts.user, posts: [newPost, ...myPosts.posts] },
           false,
         )
         console.log('投稿の作成に成功 ', newPost)

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -20,8 +20,10 @@ const Bookmark: NextPage = () => {
     [searchParams],
   )
 
+  // 古いデータがあれば、自動的に再取得
   const { data: bookmarkPosts } = useGetApi<BookmarkPosts>(
     `/folders/${folders && folders[selectedFolderIndex]?.id}`,
+    { options: { revalidateIfStale: true } },
   )
   console.log(bookmarkPosts)
   // フォルダが無い


### PR DESCRIPTION
## 関連issue
- #95

## 詳細
- 今までSWRの再取得をしていたので、useGetAPIのSWRのオプションを変更
  - revalidateIfStale: false // 古いデータがあれば、自動で再取得
  - revalidateOnFocus: false // ウィンドウがフォーカスされると自動で再取得
- post作成のmutate処理の順番を修正 [...posts, newPost] => [newPost, ...posts]
- しかし、ブックマークページはmutate処理が完璧ではないので、キャッシュが変更されない時がある。
  - ブックマーク追加、ブックマークされている投稿の編集・削除は、mutateするのが不可能。
  - そこで、ブックマークページの取得だけ、SWRのrevalidateIfStaleをtrueにすることで解決した
  - useGetApiで、revalidateIfStaleを受け取れるようにする

## 動作確認
before
networkを見ると、postsを毎回取得している
![SharePos 投稿一覧ページ - Brave 2023-01-14 08-26-41](https://user-images.githubusercontent.com/88410576/212437294-9123a302-50cd-4c56-b094-67ac24886729.gif)

after
最初の一度だけ取得して、リクエストが少なくなる

![SharePos 投稿一覧ページ - Brave 2023-01-14 08-30-44](https://user-images.githubusercontent.com/88410576/212437546-3f2279fe-511b-4814-9662-186d1358592a.gif)


ブックマークページだけ、古いデータがある時に自動で再取得する
- revalidateIfStale: falseだと変更に気付かず、ブックマーク追加が反映されない

![localhost_3000_bookmark_id=0 - Brave 2023-01-14 08-39-53](https://user-images.githubusercontent.com/88410576/212437999-fb533402-5f1a-4868-a7ae-3d97b873352b.gif)

## 自己確認
yarn build成功