### PR TITLE
TOPページの初期データはサーバーで取得する

### DIFF
--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -22,7 +22,7 @@ const Bookmark: NextPage = () => {
 
   // 古いデータがあれば、自動的に再取得
   const { data: bookmarkPosts } = useGetApi<BookmarkPosts>(
-    `/folders/${folders && folders[selectedFolderIndex]?.id}`,
+    `/folders/${(folders && folders[selectedFolderIndex]?.id) || ''}`,
     { options: { revalidateIfStale: true } },
   )
   console.log(bookmarkPosts)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,25 @@
 import { NextPage } from 'next'
 import Head from 'next/head'
 
+import { SWRConfig } from 'swr'
 import { Layout } from 'components/layout/Layout'
 import { PostItem } from 'components/post/Item/PostItem'
 import { useGetApi } from 'hooks/useApi'
 import { Post } from 'types/post'
+import { getApi } from 'utils/api'
 
-const Home: NextPage = () => {
+export async function getStaticProps() {
+  const posts = await getApi('/posts')
+  return {
+    props: {
+      fallback: {
+        '/posts': posts,
+      },
+    },
+  }
+}
+
+const Index: NextPage = () => {
   const { data: posts, error } = useGetApi<Post[]>('/posts')
 
   // コメント機能
@@ -46,10 +59,6 @@ const Home: NextPage = () => {
         <title>SharePos 投稿一覧ページ</title>
       </Head>
       <Layout>
-        {/* <Button onClick={addReplyComment}>追加</Button>
-        <Button onClick={() => updateReplyComment(13)}>更新</Button>
-        <Button onClick={() => deleteReplyComment(15)}>削除</Button> */}
-
         {posts && (
           <div className='mt-4'>
             <div className='grid gap-6 justify-center items-start sm:(grid-cols-[repeat(auto-fill,minmax(291px,auto))])'>
@@ -66,4 +75,10 @@ const Home: NextPage = () => {
   )
 }
 
-export default Home
+export default function Page({ fallback }: { fallback: { '/posts': Post[] } }) {
+  return (
+    <SWRConfig value={{ fallback }}>
+      <Index />
+    </SWRConfig>
+  )
+}


### PR DESCRIPTION
## 詳細
- TOPページの初期データ(posts)を、SSRで受け取ることで高速化を図る
- そのデータをSWRの初期値とする

## 動作確認
before
![image](https://user-images.githubusercontent.com/88410576/212703919-0f3ff155-16a8-4475-bc9e-395f0a589ad8.png)


after
遅くなってない？

![image](https://user-images.githubusercontent.com/88410576/212703813-193d780f-844a-4796-9b4a-500c86cbffba.png)

