### PR TITLE
fontSizeをデザインシステムで管理する #123

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -21,37 +21,34 @@ export const LoginForm: FC<Props> = ({ onSubmit }) => {
           onSubmit({ email, password })
           e.preventDefault()
         }}
-        className='mt-4'
       >
         <div className='max-w-300px w-80vw relative'>
-          <label htmlFor='email' className='font-bold text-sm block '>
+          <label>
             Eメール
+            <input
+              type='text'
+              value={email}
+              placeholder='example@example.com'
+              required
+              onChange={v => setEmail(v.target.value)}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            id='email'
-            type='text'
-            value={email}
-            placeholder='example@example.com'
-            required
-            onChange={v => setEmail(v.target.value)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
-          <AiOutlineMailIcon className='top-33px left-270px absolute' />
+          <AiOutlineMailIcon className='top-37px left-270px absolute' />
         </div>
         <div className='mt-2 relative '>
-          <label htmlFor='password' className='font-bold text-sm block'>
+          <label>
             パスワード
+            <input
+              type='password'
+              value={password}
+              placeholder='password'
+              required
+              onChange={v => setPassword(v.target.value)}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            id='password'
-            type='password'
-            value={password}
-            placeholder='password'
-            required
-            onChange={v => setPassword(v.target.value)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
-          <RiLockPasswordLineIcon className='top-33px left-270px absolute' />
+          <RiLockPasswordLineIcon className='top-37px left-270px absolute' />
         </div>
 
         <Button type='submit' fullWidth animate className='mt-4'>

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -37,82 +37,74 @@ export const SignUpForm: FC<Props> = ({ onSubmit }) => {
           onSubmit(formParams)
           e.preventDefault()
         }}
+        className='max-w-300px w-80vw'
       >
-        <div className='max-w-300px w-80vw relative'>
-          <label htmlFor='username' className='font-bold text-sm block '>
+        <div className='relative'>
+          <label>
             ユーザー名
+            <input
+              type='text'
+              value={formParams.username}
+              placeholder='シェアポス太郎'
+              required
+              name='username'
+              onChange={e => onChange(e)}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            type='text'
-            value={formParams.username}
-            placeholder='シェアポス太郎'
-            required
-            name='username'
-            onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
-          <AiOutlineUserIcon className='top-33px left-270px absolute' />
+          <AiOutlineUserIcon className='top-37px left-270px absolute' />
         </div>
         <div className='mt-2 relative'>
-          <label htmlFor='email' className='font-bold text-sm block '>
+          <label>
             Eメール
+            <input
+              type='email'
+              id='email'
+              value={formParams.email}
+              placeholder='example@example.com'
+              required
+              name='email'
+              onChange={e => onChange(e)}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            type='email'
-            id='email'
-            value={formParams.email}
-            placeholder='example@example.com'
-            required
-            name='email'
-            onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
-          <AiOutlineMailIcon className='top-33px left-270px absolute' />
+          <AiOutlineMailIcon className='top-37px left-270px absolute' />
         </div>
         <div className='mt-2 relative'>
-          <label htmlFor='password' className='font-bold text-sm block '>
+          <label>
             パスワード
+            <input
+              type='password'
+              id='password'
+              value={formParams.password}
+              placeholder='password'
+              required
+              minLength={6}
+              name='password'
+              onChange={e => onChange(e)}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            type='password'
-            id='password'
-            value={formParams.password}
-            placeholder='password'
-            required
-            minLength={6}
-            name='password'
-            onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
-          <RiLockPasswordLineIcon className='top-33px left-270px absolute' />
+          <RiLockPasswordLineIcon className='top-37px left-270px absolute' />
         </div>
         <div className='mt-2 relative'>
-          <label
-            htmlFor='passwordConfirmation'
-            className='font-bold text-sm block '
-          >
+          <label>
             確認用パスワード
+            <input
+              type='password'
+              id='passwordConfirmation'
+              value={formParams.passwordConfirmation}
+              required
+              minLength={6}
+              placeholder='password'
+              name='passwordConfirmation'
+              onChange={e => onChange(e)}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            type='password'
-            id='passwordConfirmation'
-            value={formParams.passwordConfirmation}
-            required
-            minLength={6}
-            placeholder='password'
-            name='passwordConfirmation'
-            onChange={e => onChange(e)}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
-          <RiLockPasswordLineIcon className='top-33px left-270px absolute' />
+          <RiLockPasswordLineIcon className='top-37px left-270px absolute' />
         </div>
-        <Button
-          type='submit'
-          color='primary'
-          fullWidth
-          className='mt-4'
-          animate
-        >
+        <Button type='submit' fullWidth className='mt-4' animate>
           登録
         </Button>
       </form>

--- a/src/components/bookmark/BookmarkFolderList.tsx
+++ b/src/components/bookmark/BookmarkFolderList.tsx
@@ -37,30 +37,39 @@ export const BookmarkFolderList: FC<Props> = ({ folders }) => {
   return (
     <div>
       {/* ブックマーク名一覧 */}
-      <div className='h-50px overflow-x-scroll scroll-bar sm:(h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll) '>
-        <div className='flex gap-2 sm:(flex-col-reverse gap-1) '>
-          {folders.map((folder, index) => (
-            <div
-              key={folder.id}
-              className={`whitespace-nowrap h-40px ${
-                routerFolderIndex == index
-                  ? 'border-b-3 border-primary-dark text-primary-dark font-bold'
-                  : 'text-gray-500 border-b-2'
-              }`}
-            >
-              <Link href={{ pathname: 'bookmark', query: { id: index } }}>
-                <div
-                  className={`flex items-center mt-2 w-full text-left  ${
-                    searchParams.get('id') == folder.id && 'font-bold'
-                  }`}
-                  onClick={() => onClickFolder(index)}
-                >
-                  <AiFillFolderIcon className='h-6 mr-1 text-accent-dark min-w-6 w-6' />
-                  {folder.name}
-                </div>
-              </Link>
-            </div>
-          ))}
+      <div
+        className='h-50px bg-primary-light overflow-x-scroll scroll-bar flex gap-2
+                  sm:(flex-col-reverse gap-1 h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll)'
+      >
+        {/* スマホ横スクロールで左右に余分を空けている */}
+        <div className='ml-2 sm:hidden' />
+
+        {folders.map((folder, index) => (
+          <div
+            key={folder.id}
+            className={`whitespace-nowrap h-40px ${
+              routerFolderIndex == index
+                ? 'border-b-3 border-primary-dark text-primary-dark font-bold'
+                : 'text-gray-500 border-b-2'
+            }`}
+          >
+            <Link href={{ pathname: 'bookmark', query: { id: index } }}>
+              <div
+                className={`flex items-center mt-2 w-full text-left  ${
+                  searchParams.get('id') == folder.id && 'font-bold'
+                }`}
+                onClick={() => onClickFolder(index)}
+              >
+                <AiFillFolderIcon className='h-6 mr-1 text-accent-dark min-w-6 w-6' />
+                {folder.name}
+              </div>
+            </Link>
+          </div>
+        ))}
+
+        {/* スマホ横スクロールで左右に余分を空けている */}
+        <div className='invisible sm:hidden' alia-hidden='true'>
+          a
         </div>
       </div>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -31,7 +31,6 @@ export const Footer: FC = () => {
           <Link href='/login'>
             <Button
               radius='xl'
-              size='md'
               compact
               className='border border-white rounded-full'
             >
@@ -39,7 +38,7 @@ export const Footer: FC = () => {
             </Button>
           </Link>
           <Link href='/signup'>
-            <Button variant='outline' radius='xl' size='md' compact>
+            <Button variant='outline' radius='xl' compact>
               新規登録
             </Button>
           </Link>
@@ -55,19 +54,19 @@ export const Footer: FC = () => {
   }[] = [
     {
       href: '/',
-      default: <AiOutlineHomeIcon />,
-      selected: <AiFillHomeIcon />,
+      default: <AiOutlineHomeIcon className='h-6 w-6' />,
+      selected: <AiFillHomeIcon className='h-6 w-6' />,
     },
     {
       href: '/bookmark',
-      default: <IoBookOutlineIcon />,
-      selected: <IoBookIcon />,
+      default: <IoBookOutlineIcon className='h-6 w-6' />,
+      selected: <IoBookIcon className='h-6 w-6' />,
     },
     {
       // href: 'myPage',
       href: `/users/${user?.id}`,
-      default: <AiOutlineUserIcon />,
-      selected: <FaUserIcon />,
+      default: <AiOutlineUserIcon className='h-6 w-6' />,
+      selected: <FaUserIcon className='h-6 w-6' />,
     },
   ]
 
@@ -75,11 +74,11 @@ export const Footer: FC = () => {
     <footer className='sm:hidden'>
       {pathname !== '/create' && <JumpToCreatePostButton />}
 
-      <nav className='bg-white flex w-full bottom-0 text-25px z-2 justify-around fixed'>
+      <nav className='bg-white flex w-full bottom-0 z-2 justify-around fixed'>
         {menuIcons.map(menuIcon => (
           <Link href={menuIcon.href} key={menuIcon.href}>
             <div
-              className={`cursor-pointer py-2 px-3 ${
+              className={`cursor-pointer pt-2 py-1 px-3 ${
                 pathname === menuIcon.href && 'text-primary-dark'
               }`}
             >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export const Header: FC = () => {
     >
       <nav className='flex mx-auto max-w-1150px px-4 items-center justify-between'>
         <Link href='/'>
-          <h1 className='cursor-pointer font-cantoreOne mt-0 text-primary-dark mb-1 text-4xl'>
+          <h1 className='cursor-pointer font-cantoreOne text-primary-dark mb-1 text-2xl leading-30px'>
             SharePos
           </h1>
         </Link>
@@ -65,7 +65,7 @@ export const Header: FC = () => {
                 <div className='cursor-pointer'>ログイン</div>
               </Link>
               <Link href='/signup'>
-                <Button radius='md'>新規登録</Button>
+                <Button>新規登録</Button>
               </Link>
             </div>
           )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export const Header: FC = () => {
     >
       <nav className='flex mx-auto max-w-1150px px-4 items-center justify-between'>
         <Link href='/'>
-          <h1 className='cursor-pointer font-cantoreOne text-primary-dark mb-1 text-2xl leading-30px'>
+          <h1 className='cursor-pointer font-cantoreOne text-primary-dark mb-1 text-2xl'>
             SharePos
           </h1>
         </Link>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,9 +11,7 @@ export const Layout: FC<Props> = ({ children }) => {
     <div className='bg-primary-light min-h-screen'>
       <Header />
       <main>
-        <div className='mx-auto max-w-1150px px-4 pt-50px pb-150px'>
-          {children}
-        </div>
+        <div className='mx-auto max-w-1150px px-4 pt-12 pb-36'>{children}</div>
       </main>
       <Footer />
     </div>

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -54,18 +54,18 @@ export const PostForm: FC<Props> = ({
         className='w-full max-w-420px relative'
       >
         <div className='relative'>
-          <label htmlFor='username' className='font-bold text-sm block '>
+          <label>
             記事のURL
+            <input
+              type='text'
+              value={formParams.url}
+              placeholder='https://example.com'
+              required
+              name='url'
+              onChange={onChange}
+              className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
+            />
           </label>
-          <input
-            type='text'
-            value={formParams.url}
-            placeholder='https://example.com'
-            required
-            name='url'
-            onChange={onChange}
-            className='border outline-none ring-primary-dark w-full p-2 pr-9 duration-300 focus:rounded-md focus:ring-1'
-          />
 
           <div className='flex justify-end'>
             <RiArticleLineIcon className='top-33px right-10px absolute' />
@@ -73,65 +73,66 @@ export const PostForm: FC<Props> = ({
         </div>
 
         <div className='mt-2 relative'>
-          <label htmlFor='username' className='font-bold text-sm block '>
+          <label>
             コメント
-          </label>
-
-          <div className='min-h-[50px] leading-1.4rem relative'>
-            <div
-              className='py-3 invisible whitespace-pre-wrap'
-              aria-hidden='true'
-            >
-              この文字で　編集時の　PostItemの横幅を　最大に　保っている
-              {formParams.comment}
+            <div className='min-h-[50px] leading-1.4rem relative'>
+              <div
+                className='py-3 invisible whitespace-pre-wrap'
+                aria-hidden='true'
+              >
+                この文字で　編集時の　PostItemの横幅を　最大に　保っている
+                {formParams.comment}
+              </div>
+              <textarea
+                name='comment'
+                className='border h-full outline-none ring-primary-dark w-full p-2 pr-9 top-0 left-0 duration-300 scroll-bar-none absolute focus:rounded-md focus:ring-1'
+                value={formParams.comment}
+                placeholder='この記事オススメ！'
+                onChange={onChange}
+              />
             </div>
-            <textarea
-              name='comment'
-              className='border h-full outline-none ring-primary-dark w-full p-2 pr-9 top-0 left-0 duration-300 scroll-bar-none absolute focus:rounded-md focus:ring-1'
-              value={formParams.comment}
-              placeholder='この記事オススメ！'
-              onChange={onChange}
-            />
-          </div>
+          </label>
           <div className='flex justify-end'>
             <BiCommentDetailIcon className='top-33px right-10px absolute' />
           </div>
         </div>
 
         <div className='mt-2 relative'>
-          <label htmlFor='username' className='font-bold text-sm block '>
+          <label>
             公開設定
-          </label>
-          <div>
-            <div
-              className={`rounded-full cursor-pointer ${
-                formParams.published ? 'bg-accent-dark' : 'bg-primary-dark'
-              } h-28px mt-2 text-white w-90px relative inline-block`}
-              onClick={() =>
-                setFormParams(state => {
-                  return {
-                    ...state,
-                    published: !formParams.published,
-                  }
-                })
-              }
-            >
-              <div className='font-bold text-white text-md transform top-[2px] left-[5px] absolute'>
-                公開
-                <span className='ml-3px transform scale-x-80 inline-block'>
-                  非公開
-                </span>
-              </div>
+            <div>
               <div
-                className={`bg-white h-20px rounded-full top-4px ${
-                  formParams.published ? 'left-40px w-46px' : 'left-3px w-38px'
-                } duration-150 absolute`}
+                className={`rounded-full cursor-pointer ${
+                  formParams.published ? 'bg-accent-dark' : 'bg-primary-dark'
+                } h-28px text-white w-90px relative inline-block`}
+                onClick={() =>
+                  setFormParams(state => {
+                    return {
+                      ...state,
+                      published: !formParams.published,
+                    }
+                  })
+                }
               >
-                <input type='radio' name='a' className='opacity-0' />
-                <input type='radio' name='a' className='opacity-0' />
+                <div className='font-bold text-white transform top-[2px] left-[5px] absolute'>
+                  公開
+                  <span className='ml-3px transform scale-x-80 inline-block'>
+                    非公開
+                  </span>
+                </div>
+                <div
+                  className={`bg-white h-20px rounded-full top-4px ${
+                    formParams.published
+                      ? 'left-40px w-46px'
+                      : 'left-3px w-38px'
+                  } duration-150 absolute`}
+                >
+                  <input type='radio' name='a' className='opacity-0' />
+                  <input type='radio' name='a' className='opacity-0' />
+                </div>
               </div>
             </div>
-          </div>
+          </label>
         </div>
         <Button type='submit' fullWidth animate className='mt-4'>
           {submitButtonText}

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -31,7 +31,7 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
     <article className='bg-white rounded-md shadow-xl max-w-460px p-4 w-100% sm:w-291px'>
       <div className='flex justify-between items-center'>
         <Link href={`/users/${post.user.id}`}>
-          <div className='cursor-pointer flex font-bold text-20px gap-2 items-center'>
+          <div className='cursor-pointer flex font-bold text-lg gap-2 items-center'>
             <Avatar id={post.userId} />
             {post.user.username}
           </div>
@@ -86,7 +86,7 @@ export const PostItem: FC<Props> = ({ post, bookmarkFolderId = '' }) => {
               ) : (
                 <p />
               )}
-              <p className='text-13px'>{calcHowManyDaysAgo(post.createdAt)}</p>
+              <p className='text-sm'>{calcHowManyDaysAgo(post.createdAt)}</p>
             </div>
           </>
         )}

--- a/src/components/post/PostLinkCard.tsx
+++ b/src/components/post/PostLinkCard.tsx
@@ -32,17 +32,17 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
                 objectFit='contain'
               />
             ) : (
-              <div className='flex h-full bg-gray-300 text-mono w-full max-h-225px transform text-30px duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
+              <div className='flex h-full bg-gray-300 text-mono w-full max-h-225px transform text-2xl duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
                 No image
               </div>
             )}
           </div>
 
-          <figcaption className='p-2'>
-            <p className='text-13px text-gray-500'>
+          <figcaption className='text-sm p-2'>
+            <p className='text-gray-500'>
               {post.url.split('//')[1].split('/')[0]}
             </p>
-            <div className='h-37px mt-2 text-sm overflow-hidden'>
+            <div className='h-39px mt-1 overflow-hidden'>
               {post.metaInfo.title}
             </div>
           </figcaption>

--- a/src/components/post/PostMenuButton.tsx
+++ b/src/components/post/PostMenuButton.tsx
@@ -43,7 +43,7 @@ export const PostMenuButton: FC<Props> = ({
   return (
     <div className='flex relative'>
       <BsThreeDotsIcon
-        className='cursor-pointer text-30px duration-100 hover:opacity-50'
+        className='cursor-pointer text-2xl duration-100 hover:opacity-50'
         onClick={() => setIsOpenedMenu(!isOpenedMenu)}
       />
 
@@ -71,7 +71,7 @@ export const PostMenuButton: FC<Props> = ({
               }}
             >
               投稿を
-              <span className='font-bold text-danger-dark text-18px'>削除</span>
+              <span className='font-bold text-danger-dark'>削除</span>
               する
             </button>
           </>
@@ -108,9 +108,7 @@ export const PostMenuButton: FC<Props> = ({
                 }}
               >
                 ブックマークを
-                <span className='font-bold text-danger-dark text-18px'>
-                  削除
-                </span>
+                <span className='font-bold text-danger-dark'>削除</span>
               </button>
             )}
           </>

--- a/src/components/shares/JumpToCreatePostButton.tsx
+++ b/src/components/shares/JumpToCreatePostButton.tsx
@@ -13,12 +13,12 @@ export const JumpToCreatePostButton: FC = () => {
 
   return (
     <Link href='/create'>
-      <div className='bg-accent-dark rounded-full flex font-bold text-white py-10px px-11.5px right-20px bottom-50px text-30px z-2 fixed'>
+      <div className='bg-accent-dark rounded-full flex font-bold text-white py-10px px-11.5px right-20px text-lg leading-1.1rem bottom-50px z-2 fixed'>
         <div className='my-auto'>
           <div
             className={`${
               isShowText ? 'w-25' : 'translate-x-100% w-0'
-            } h-5 transform text-20px overflow-hidden duration-500`}
+            } h-5 transform overflow-hidden duration-500`}
           >
             シェアする
           </div>

--- a/src/components/shares/base/Button.tsx
+++ b/src/components/shares/base/Button.tsx
@@ -89,7 +89,7 @@ export const Button: FC<Props> = ({
         case 'xs':
           return 'text-12px py-4px px-7px'
         case 'sm':
-          return 'text-14px py-5px px-8px'
+          return 'text-16px py-5px px-8px'
         case 'md':
           return 'text-16px py-6px px-10px'
         case 'lg':
@@ -102,7 +102,7 @@ export const Button: FC<Props> = ({
       case 'xs':
         return 'text-12px py-8px px-14px'
       case 'sm':
-        return 'text-14px py-10px px-18px'
+        return 'text-16px py-10px px-18px'
       case 'md':
         return 'text-16px py-12px px-22px'
       case 'lg':

--- a/src/components/shares/base/Button.tsx
+++ b/src/components/shares/base/Button.tsx
@@ -87,28 +87,28 @@ export const Button: FC<Props> = ({
     if (compact) {
       switch (size) {
         case 'xs':
-          return 'text-12px py-4px px-7px'
+          return 'text-sm py-4px px-7px'
         case 'sm':
-          return 'text-16px py-5px px-8px'
+          return 'text-md py-5px px-8px'
         case 'md':
-          return 'text-16px py-6px px-10px'
+          return 'text-md py-6px px-10px'
         case 'lg':
-          return 'text-18px py-7px px-12px'
+          return 'text-lg py-7px px-12px'
         case 'xl':
-          return 'text-20px py-9px px-14px'
+          return 'text-lg py-9px px-14px'
       }
     }
     switch (size) {
       case 'xs':
-        return 'text-12px py-8px px-14px'
+        return 'text-sm py-8px px-14px'
       case 'sm':
-        return 'text-16px py-10px px-18px'
+        return 'text-md py-10px px-18px'
       case 'md':
-        return 'text-16px py-12px px-22px'
+        return 'text-md py-12px px-22px'
       case 'lg':
-        return 'text-18px py-15px px-26px'
+        return 'text-lg py-15px px-26px'
       case 'xl':
-        return 'text-20px py-19px px-32px'
+        return 'text-lg py-19px px-32px'
     }
   }, [compact, size])
 

--- a/src/components/shares/base/Modal.tsx
+++ b/src/components/shares/base/Modal.tsx
@@ -21,7 +21,7 @@ export const Modal: FC<Props> = ({ open, onClose, title, children }) => {
 
             <Dialog.Panel className='transform top-[50%] left-[50%] z-2 translate-x-[-50%] translate-y-[-50%] fixed'>
               <div className='bg-white bg-opacity-97 rounded-md shadow-2xl w-300px '>
-                <Dialog.Title className='font-bold text-center text-xl px-2 pt-4'>
+                <Dialog.Title className='font-bold text-center text-lg px-2 pt-4'>
                   {title}
                 </Dialog.Title>
                 <Dialog.Description className='mt-2'>

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -31,7 +31,7 @@ const Bookmark: NextPage = () => {
     return (
       <Layout>
         <div className='flex ml-4 justify-between'>
-          <h1 className='font-bold text-2xl'>ブックマーク</h1>
+          <h1 className='font-bold text-xl'>ブックマーク</h1>
           <div>
             <CreateFolderButton />
           </div>
@@ -47,27 +47,33 @@ const Bookmark: NextPage = () => {
 
   return (
     <Layout>
-      <div className='flex ml-4 justify-between'>
-        <h1 className='font-bold text-2xl'>ブックマーク</h1>
-        <div className='sm:hidden'>
+      {/* スマホ */}
+      <div className='sm:hidden flex items-center justify-between'>
+        <h1 className='font-bold text-xl'>ブックマーク</h1>
+        <div>
           <CreateFolderButton />
         </div>
       </div>
 
       <div className='sm:(flex gap-3 items-start) '>
         {/* 自分のフォルダ一覧 */}
-        <div className='bg-primary-light mx-[-16px] pb-[10px] pl-4 top-0px z-2 sticky sm:(z-1 mx-0 top-100px) '>
-          <div className='mt-4 hidden sm:block'>
-            <CreateFolderButton />
+        <div className='bg-primary-light top-0px ml-0 z-2 sticky sm:(z-1 top-20 ml-4) '>
+          {/* PC */}
+          <div className='hidden sm:block'>
+            <h1 className='font-bold text-xl'>ブックマーク</h1>
+            <div className='mt-12'>
+              <CreateFolderButton />
+            </div>
           </div>
-          <div className='mt-5'>
+
+          <div className='mt-4 sm:(mt-4 mx-0) mx-[-16px]'>
             <BookmarkFolderList folders={folders} />
           </div>
         </div>
 
         {/* 選択しているフォルダの記事一覧 */}
         {bookmarkPosts?.posts.length && folders ? (
-          <div className='mt-4 w-full'>
+          <div className='mt-12 sm:mt-21 w-full'>
             <div className='grid gap-6 justify-center items-start sm:(gap-x-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
               {bookmarkPosts.posts.map((post, index) => (
                 <PostItem

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -12,11 +12,11 @@ const Create: NextPage = () => {
   return (
     <>
       <Head>
-        <title>SharePos 記事投稿ページ</title>
+        <title>SharePos 記事シェアページ</title>
       </Head>
       <Layout>
-        <h1 className='text-center text-lg'>記事投稿</h1>
-        <div className='mt-8'>
+        <h1 className='font-bold text-center text-xl'>記事をシェア</h1>
+        <div className='mt-12'>
           <PostForm onSubmit={createPost} />
         </div>
       </Layout>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -31,13 +31,15 @@ const Login: NextPage = () => {
         <title>SharePos ログインページ</title>
       </Head>
       <Layout>
-        <h1 className='text-center text-lg'>ログイン</h1>
-        <LoginForm onSubmit={onSubmit} />
+        <h1 className='text-center text-xl font-bold'>ログイン</h1>
+        <div className='mt-12'>
+          <LoginForm onSubmit={onSubmit} />
+        </div>
 
         <p className='mt-4 text-center'>
           新規登録は
           <Link href='/signup'>
-            <span className='font-bold text-accent-dark text-lg'>こちら</span>
+            <span className='font-bold text-accent-dark'>こちら</span>
           </Link>
         </p>
       </Layout>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -36,15 +36,15 @@ const SignUp: NextPage = () => {
         <title>SharePos 新規登録ページ</title>
       </Head>
       <Layout>
-        <h1 className='text-center text-lg'>新規登録</h1>
-        <div className='mt-4'>
+        <h1 className='text-center text-xl font-bold'>新規登録</h1>
+        <div className='mt-12'>
           <SignUpForm onSubmit={onSubmit} />
         </div>
 
         <p className='mt-4 text-center'>
           ログインは
           <Link href='/login'>
-            <span className='font-bold text-accent-dark text-lg'>こちら</span>
+            <span className='font-bold text-accent-dark'>こちら</span>
           </Link>
         </p>
       </Layout>

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -54,6 +54,7 @@ const User: NextPage = () => {
             {isMyPage ? (
               <Button
                 radius='xs'
+                size='sm'
                 variant='default'
                 className='whitespace-nowrap'
               >
@@ -85,7 +86,7 @@ const User: NextPage = () => {
                 <button
                   key={tab.label}
                   onClick={() => setSelectedPublished(tab.published)}
-                  className={`text-xl pb-1 w-50vw sm:w-100px ${
+                  className={`text-lg pb-1 w-50vw sm:w-100px ${
                     selectedPublished === tab.published &&
                     'font-bold border-b-3 border-primary-dark text-primary-dark'
                   }`}

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,5 +1,4 @@
 // color
-
 const base = {
   green: '#0b7e7f',
   lightGreen: '#dfecee',
@@ -38,4 +37,13 @@ export const rounded = {
   md: '7px',
   lg: '15px',
   xl: '100%',
+}
+
+// fontSize
+export const fontSize = {
+  sm: '14px',
+  md: '16px',
+  lg: '20px',
+  xl: '24px',
+  '2xl': '30px',
 }

--- a/windi.config.js
+++ b/windi.config.js
@@ -1,5 +1,12 @@
 import { defineConfig } from 'windicss/helpers'
-import { accent, danger, primary, rounded, secondary } from './src/utils/theme'
+import {
+  accent,
+  danger,
+  primary,
+  rounded,
+  secondary,
+  fontSize,
+} from './src/utils/theme'
 
 export default defineConfig({
   extract: {
@@ -27,11 +34,11 @@ export default defineConfig({
         },
       },
       fontSize: {
-        sm: '14px',
-        md: '16px',
-        lg: '20px',
-        xl: '24px',
-        '2xl': '30px',
+        sm: fontSize.sm,
+        md: fontSize.md,
+        lg: fontSize.lg,
+        xl: fontSize.xl,
+        '2xl': fontSize['2xl'],
       },
       fontFamily: {
         cantoreOne: ['var(--font-cantoreOne)'],

--- a/windi.config.js
+++ b/windi.config.js
@@ -34,11 +34,11 @@ export default defineConfig({
         },
       },
       fontSize: {
-        sm: fontSize.sm,
-        md: fontSize.md,
-        lg: fontSize.lg,
-        xl: fontSize.xl,
-        '2xl': fontSize['2xl'],
+        sm: [fontSize.sm, fontSize.sm],
+        md: [fontSize.md, fontSize.md],
+        lg: [fontSize.lg, fontSize.lg],
+        xl: [fontSize.xl, fontSize.xl],
+        '2xl': [fontSize['2xl'], fontSize['2xl']],
       },
       fontFamily: {
         cantoreOne: ['var(--font-cantoreOne)'],

--- a/windi.config.js
+++ b/windi.config.js
@@ -26,6 +26,13 @@ export default defineConfig({
           dark: secondary.dark,
         },
       },
+      fontSize: {
+        sm: '14px',
+        md: '16px',
+        lg: '20px',
+        xl: '24px',
+        '2xl': '30px',
+      },
       fontFamily: {
         cantoreOne: ['var(--font-cantoreOne)'],
       },


### PR DESCRIPTION
## 関連 Issue

- #123 

## 詳細

- fontSizeをwindi.config のテーマで管理する
  - sm: 14px, md: 16px, lg: 20px, xl: 24px, 2xl: 30
    - sm: 小さい文字に使う
    - md: デフォルト
    - lg: PostItemの名前、Modalのタイトル等
    - xl: ページタイトル
    - 2xl: ヘッダーのSharePos等
- フォームの見た目を統一
  - labelでinputを括る
  - margin, fontSize
- ブックマーク
  - スマホの、フォルダ一覧を最大画面幅でスクロール出来るように
  - h1のブックマークもstickyするように


## 動作確認
before
![image](https://user-images.githubusercontent.com/88410576/215931317-c0ab6961-5706-4dd6-8ac1-062ad05e2d0b.png)

after
![image](https://user-images.githubusercontent.com/88410576/215931342-5b80bac5-8e9b-4b6a-a40e-cb53b8fa4146.png)

before
![image](https://user-images.githubusercontent.com/88410576/215931379-71834070-7991-4e1f-85ac-938e63ed2053.png)

after
![image](https://user-images.githubusercontent.com/88410576/215931426-dd24ec88-84fa-4ebb-bb8f-dc00311d4a6d.png)

before
![image](https://user-images.githubusercontent.com/88410576/215931573-b01a0e27-dab6-4227-a941-92e4d3da9828.png)

after
![image](https://user-images.githubusercontent.com/88410576/215931596-ce036e70-ec90-49fa-b94e-fca7ebb58020.png)

before
![image](https://user-images.githubusercontent.com/88410576/215931796-11977f66-5cce-4d9c-aecb-a5517a9be0ed.png)

after
![image](https://user-images.githubusercontent.com/88410576/215931871-633ba321-047f-4f3e-8524-cd105792afe7.png)

before
![image](https://user-images.githubusercontent.com/88410576/215933121-2f5e297e-52b3-4a40-b6e2-b8cc4898babd.png)

after
![image](https://user-images.githubusercontent.com/88410576/215933147-30be4d20-a03d-490b-b7ef-90f95eb797ed.png)

