### PR TITLE
Feature/change data count pagination

### DIFF
--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -28,15 +28,9 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
 
   const { data: followers, mutate: mutateFollowers } = useGetApi<UserInfo[]>(
     `/users/${userProfile?.user.id}/followers`,
-    {
-      options: { revalidateIfStale: true },
-    },
   )
   const { data: followings, mutate: mutateFollowings } = useGetApi<UserInfo[]>(
     `/users/${userProfile?.user.id}/followings`,
-    {
-      options: { revalidateIfStale: true },
-    },
   )
 
   return (

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -37,14 +37,14 @@ export const useGetInfinite = <Data = any>(
     body: Record<string, any>
     header: Record<string, string>
   },
-  limit = 24,
+  limit = 12,
 ) => {
   const getKey = useCallback(
     (pageIndex: number, previousPageData: Data[][]) => {
       if (previousPageData && !previousPageData.length) return null // 最後に到達した
-      return `${url}?page=${pageIndex + 1}` // SWR キー
+      return `${url}?page=${pageIndex + 1}&per=${limit}` // SWR キー
     },
-    [url],
+    [limit, url],
   )
 
   const fetcher = useCallback(


### PR DESCRIPTION
## 関連 Issue

- #159 

## 詳細
- ページネーションのデータ取得量を24=>12に変更
- users/:idページで、毎回followings, followersを再検証していたのを辞める
  - モーダル表示する度に、再検証してるから必要ない
