### PR TITLE
useSWRInfiniteで毎回1ページ目を取得しない

### DIFF
--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -60,6 +60,7 @@ export const useGetInfinite = <Data = any>(
       revalidateOnReconnect: false,
       revalidateIfStale: false,
       revalidateOnFocus: false,
+      revalidateFirstPage: false,
     },
   )
 
@@ -77,7 +78,7 @@ export const useGetInfinite = <Data = any>(
 
   return {
     ...SWRInfiniteResponse,
-    data: data?.flat(),
+    data: data?.flat(), // Data[][]を、Data[]に変換する
     isReachingEnd,
     fetchMore,
   }


### PR DESCRIPTION
 useSWRInfiniteで毎回1ページ目を取得しない

## 関連 Issue

- #159 
- #169 

## 詳細

- useSWRInfiniteの初期設定で、2ページ目以降を呼ぶたびに1ページ目を呼んでいたのでオフにする。

## 動作確認
before
![image](https://user-images.githubusercontent.com/88410576/225834126-10ecd21f-86ed-4b07-a6b5-4432aa51c690.png)

after
![image](https://user-images.githubusercontent.com/88410576/225834177-43f6613f-3c7e-494c-b897-61bde8a55548.png)

