### PR TITLE
3つのレイアウト崩れを修正

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -29,8 +29,8 @@ export const LoginForm: FC<Props> = ({ onSubmit }) => {
 
   return (
     <div className='flex flex-col items-center justify-center'>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <div className='max-w-300px w-80vw relative'>
+      <form onSubmit={handleSubmit(onSubmit)} className='max-w-300px w-80vw'>
+        <div className='relative'>
           <label>
             Eメール
             <input

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -38,7 +38,12 @@ export const Footer: FC = () => {
             </Button>
           </Link>
           <Link href='/signup'>
-            <Button variant='outline' radius='xl' compact>
+            <Button
+              variant='outline'
+              radius='xl'
+              compact
+              className='border border-white rounded-full'
+            >
               新規登録
             </Button>
           </Link>
@@ -63,7 +68,6 @@ export const Footer: FC = () => {
       selected: <IoBookIcon className='h-6 w-6' />,
     },
     {
-      // href: 'myPage',
       href: `/users/${user?.id}`,
       default: <AiOutlineUserIcon className='h-6 w-6' />,
       selected: <FaUserIcon className='h-6 w-6' />,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,7 +28,7 @@ export const Header: FC = () => {
     >
       <nav className='flex mx-auto max-w-1150px px-4 items-center justify-between'>
         <Link href='/'>
-          <h1 className='cursor-pointer font-cantoreOne text-primary-dark mb-1 text-2xl'>
+          <h1 className='cursor-pointer font-cantoreOne text-primary-dark mb-1 text-2xl leading-2xl'>
             SharePos
           </h1>
         </Link>

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -79,7 +79,7 @@ export const PostForm: FC<Props> = ({
         <div className='mt-2 relative'>
           <label>
             コメント
-            <div className='min-h-[50px] leading-1.4rem relative'>
+            <div className='min-h-[50px] relative'>
               <div
                 className='py-3 w-80vw break-words invisible sm:w-full'
                 aria-hidden='true'

--- a/src/components/post/PostLinkCard.tsx
+++ b/src/components/post/PostLinkCard.tsx
@@ -42,10 +42,10 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
           </div>
 
           <figcaption className='text-sm p-2'>
-            <p className='text-gray-500'>
+            <p className='leading-sm text-gray-500'>
               {post.url.split('//')[1].split('/')[0]}
             </p>
-            <div className='h-37px mt-2 text-sm overflow-hidden'>
+            <div className='h-38px mt-2 overflow-hidden'>
               {post.metaInfo?.title}
             </div>
           </figcaption>

--- a/src/components/shares/base/Button.tsx
+++ b/src/components/shares/base/Button.tsx
@@ -90,28 +90,28 @@ export const Button: FC<Props> = ({
     if (compact) {
       switch (size) {
         case 'xs':
-          return 'text-sm py-4px px-7px'
+          return 'text-sm leading-sm py-4px px-7px'
         case 'sm':
-          return 'text-md py-5px px-8px'
+          return 'text-md leading-md py-5px px-8px'
         case 'md':
-          return 'text-md py-6px px-10px'
+          return 'text-md leading-md py-6px px-10px'
         case 'lg':
-          return 'text-lg py-7px px-12px'
+          return 'text-lg leading-lg py-7px px-12px'
         case 'xl':
-          return 'text-lg py-9px px-14px'
+          return 'text-lg leading-lg py-9px px-14px'
       }
     }
     switch (size) {
       case 'xs':
-        return 'text-sm py-8px px-14px'
+        return 'text-sm leading-sm py-8px px-14px'
       case 'sm':
-        return 'text-md py-10px px-18px'
+        return 'text-md leading-md py-10px px-18px'
       case 'md':
-        return 'text-md py-12px px-22px'
+        return 'text-md leading-md py-12px px-22px'
       case 'lg':
-        return 'text-lg py-15px px-26px'
+        return 'text-lg leading-lg py-15px px-26px'
       case 'xl':
-        return 'text-lg py-19px px-32px'
+        return 'text-lg leading-lg py-19px px-32px'
     }
   }, [compact, size])
 
@@ -143,17 +143,3 @@ export const Button: FC<Props> = ({
     </button>
   )
 }
-
-// const allClass = `${defaultClass} ${colorClass} ${animateClass} ${sizeClass} ${RadiusClass} ${fullWidthClass} ${borderWhiteClass}`
-
-// // border border-white出来る
-// // padding margin 出来ない
-// return (
-//   <button className={className} onClick={onClick} type={type}>
-//     <span className={allClass}>
-//       {leftIcon}
-//       {children}
-//       {rightIcon}
-//     </span>
-//   </button>
-// )

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -65,6 +65,65 @@ const Test: NextPage = () => {
   return (
     <Layout>
       <div className='flex flex-col gap-5'>
+        {colors.map(color => (
+          <div key={color}>
+            <div className='flex gap-2 items-start'>
+              <Button color={color} size='xs'>
+                シェアする
+              </Button>
+              <Button color={color} size='sm'>
+                シェアする
+              </Button>
+              <Button color={color} size='md'>
+                シェアする
+              </Button>
+              <Button color={color} size='lg'>
+                シェアする
+              </Button>
+              <Button color={color} size='xl' radius='sm'>
+                シェアする
+              </Button>
+            </div>
+            <div className='flex mt-2 gap-2 items-start'>
+              <Button color={color} size='xs' compact>
+                Settings
+              </Button>
+              <Button color={color} size='sm' compact>
+                Settings
+              </Button>
+              <Button color={color} size='md' compact>
+                Settings
+              </Button>
+              <Button color={color} size='lg' compact>
+                Settings
+              </Button>
+              <Button color={color} size='xl' compact radius='sm'>
+                Settings
+              </Button>
+            </div>
+
+            <div className='flex gap-2 items-start'>
+              <Button color={color}>filled</Button>
+              <Button color={color} variant='light'>
+                light
+              </Button>
+              <Button color={color} variant='outline'>
+                outline
+              </Button>
+            </div>
+            <div className='flex mt-4 gap-2 items-start'>
+              <Button color={color} animate>
+                filled
+              </Button>
+              <Button color={color} animate variant='light'>
+                light
+              </Button>
+              <Button color={color} animate variant='outline'>
+                outline
+              </Button>
+            </div>
+          </div>
+        ))}
         {/* <ComponentA func={() => console.log('a')} /> */}
         <ComponentA text='A1' />
         <ComponentA key={String(open.v)} text={'A2'} />
@@ -108,48 +167,11 @@ const Test: NextPage = () => {
           </DropDownMenu>
         </div>
 
-        {colors.map(color => (
-          <div key={color}>
-            <div className='flex gap-2 items-start'>
-              <Button color={color} size='xs'>
-                Settings
-              </Button>
-              <Button color={color} size='sm'>
-                Settings
-              </Button>
-              <Button color={color} size='md'>
-                Settings
-              </Button>
-              <Button color={color} size='lg'>
-                Settings
-              </Button>
-              <Button color={color} size='xl' radius='sm'>
-                Settings
-              </Button>
-            </div>
-
-            <div className='flex gap-2 items-start'>
-              <Button color={color}>filled</Button>
-              <Button color={color} variant='light'>
-                light
-              </Button>
-              <Button color={color} variant='outline'>
-                outline
-              </Button>
-            </div>
-            <div className='flex mt-4 gap-2 items-start'>
-              <Button color={color} animate>
-                filled
-              </Button>
-              <Button color={color} animate variant='light'>
-                light
-              </Button>
-              <Button color={color} animate variant='outline'>
-                outline
-              </Button>
-            </div>
-          </div>
-        ))}
+        <div className='bg-white text-sm w-100px'>aaaaa ffff aaa aa</div>
+        <div className='bg-white text-md w-100px'>aaaaa ffff aaa aa</div>
+        <div className='bg-white text-lg w-100px'>aaaaa ffff aaa aa</div>
+        <div className='bg-white text-xl w-100px'>aaaaa ffff aaa aa</div>
+        <div className='bg-white text-2xl w-100px'>aaaaa ffff aaa aa</div>
       </div>
     </Layout>
   )

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -36,7 +36,7 @@ export const rounded = {
   md: '7px',
   lg: '15px',
   xl: '100%',
-}
+} as const
 
 export const fontSize = {
   sm: '14px',
@@ -44,7 +44,7 @@ export const fontSize = {
   lg: '20px',
   xl: '24px',
   '2xl': '30px',
-}
+} as const
 
 export const lineHeight = {
   sm: '20px',
@@ -52,4 +52,4 @@ export const lineHeight = {
   lg: '28px',
   xl: '32px',
   '2xl': '43px',
-}
+} as const

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -30,7 +30,6 @@ export const secondary = {
   dark: base.gray,
 } as const
 
-// rounded
 export const rounded = {
   xs: '0x',
   sm: '3px',
@@ -39,11 +38,18 @@ export const rounded = {
   xl: '100%',
 }
 
-// fontSize
 export const fontSize = {
   sm: '14px',
   md: '16px',
   lg: '20px',
   xl: '24px',
   '2xl': '30px',
+}
+
+export const lineHeight = {
+  sm: '20px',
+  md: '24px',
+  lg: '28px',
+  xl: '32px',
+  '2xl': '43px',
 }

--- a/windi.config.js
+++ b/windi.config.js
@@ -6,6 +6,7 @@ import {
   rounded,
   secondary,
   fontSize,
+  lineHeight,
 } from './src/utils/theme'
 
 export default defineConfig({
@@ -34,11 +35,18 @@ export default defineConfig({
         },
       },
       fontSize: {
-        sm: [fontSize.sm, fontSize.sm],
-        md: [fontSize.md, fontSize.md],
-        lg: [fontSize.lg, fontSize.lg],
-        xl: [fontSize.xl, fontSize.xl],
-        '2xl': [fontSize['2xl'], fontSize['2xl']],
+        sm: [fontSize.sm, lineHeight.sm],
+        md: [fontSize.md, lineHeight.md],
+        lg: [fontSize.lg, lineHeight.lg],
+        xl: [fontSize.xl, lineHeight.xl],
+        '2xl': [fontSize['2xl'], lineHeight['2xl']],
+      },
+      lineHeight: {
+        sm: fontSize.sm,
+        md: fontSize.md,
+        lg: fontSize.lg,
+        xl: fontSize.xl,
+        '2xl': fontSize['2xl'],
       },
       fontFamily: {
         cantoreOne: ['var(--font-cantoreOne)'],


### PR DESCRIPTION
## 関連 Issue

- #150

## 詳細
- ログイン前フッターのボタンの大きさを揃える
- ログインページのフォームレイアウト崩れ修正
- フォントのlineHeightを整える
  - windi.configのフォント毎のlineHeightを修正
    - text-〇〇 => [fontSize, lineHeight]
    - text-sm => [14px, 20px]
    - text-md => [16px, 24px]
    - text-lg => [20px, 28px]
    - text-xl => [24px, 32px]
    - text-2xl => [30px, 43px]
- windi.configのlineHeightも設定。これはleading-smのように使う
  - sm: fontSize.sm(14px)
  - md: fontSize.md(16px)
  - lg: fontSize.lg(20px)
  - xl: fontSize.xl(24px)
  - 2xl: fontSize.2xl(30px)
- windi.configで設定したlineHeightとは個別に、lineHeightを修正する箇所
  - PostLinkCardの記事URLのtitle
  - HeaderのSharePos
  - スマホ画面フッターのシェアする
  - Buttonコンポーネント


## 微妙な点
- windi.configのlineHeightの値をfontSizeにしている。これは、text-smを使うときのlineHeightをtext-smと同じpxにしたい時があるので設定した。
  - leading-sm => fontSize.sm(14px)
  - 例）className="text-sm leading-sm" fontSize、lineHeightどちらも14px
表示している文字列で、改行する箇所があるのは`text-sm`と`text-md`だけ。
さらに、text-2xlはこのlineHeightで使う場所が一つもなく、使うところではlineHeightを個別に設定して使っている。



## 動作確認
### ログイン前フッターのボタンの大きさを揃える
before

![image](https://user-images.githubusercontent.com/88410576/226094895-8d7c0036-9880-400f-b7bf-2bfd331f8d9b.png)

after
![image](https://user-images.githubusercontent.com/88410576/226094947-d6c3d737-97e5-4e40-9e83-5acfafb7babb.png)

### ログインページのフォームレイアウト崩れ修正
パスワードの文字が長くなっても崩れない（PCではもともと崩れておらず、スマホ画面のみbeforeのように崩れていた）

before
![image](https://user-images.githubusercontent.com/88410576/226095032-172f26b0-0495-4745-8d3e-7b42060caa9f.png)


after

![image](https://user-images.githubusercontent.com/88410576/226095037-f3f62901-ec5d-4158-8c41-720c2f237b7e.png)

### PostLinCardのlineHeightを修正

before

![image](https://user-images.githubusercontent.com/88410576/226095177-67bbad61-0657-4390-8f0d-a0e24f0e2775.png)

after

![image](https://user-images.githubusercontent.com/88410576/226095129-58540966-7d9c-4d5a-bb6c-56e0c9e61f3d.png)


