### PR TITLE
押せる要素をbuttonタグに変更

### DIFF
--- a/src/components/post/PostLinkCard.tsx
+++ b/src/components/post/PostLinkCard.tsx
@@ -21,14 +21,19 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
   }, [post.metaInfo?.image])
 
   return (
-    <>
-      <figure className='rounded-md border-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
-        <a href={post.url} target='_blank' rel='noreferrer'>
+    <figure>
+      <a
+        href={post.url}
+        target='_blank'
+        rel='noreferrer'
+      >
+        <div className='rounded-md border-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
           <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
             {displayURL ? (
               <Image
                 src={displayURL}
-                alt=''
+                alt='記事のサムネイル画像'
+                title={`${post.metaInfo?.title}へ移動します`}
                 className='bg-gray-100 transform duration-300 group-hover:scale-110'
                 width={430}
                 height={2000}
@@ -49,8 +54,8 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
               {post.metaInfo?.title}
             </div>
           </figcaption>
-        </a>
-      </figure>
-    </>
+        </div>
+      </a>
+    </figure>
   )
 }

--- a/src/components/post/PostMenuButton.tsx
+++ b/src/components/post/PostMenuButton.tsx
@@ -42,10 +42,12 @@ export const PostMenuButton: FC<Props> = ({
 
   return (
     <div className='flex relative'>
-      <BsThreeDotsIcon
-        className='cursor-pointer text-2xl duration-100 hover:opacity-50'
+      <button
+        className='cursor-pointer flex'
         onClick={isMenuOpened.toggle}
-      />
+      >
+        <BsThreeDotsIcon className='text-2xl duration-100 hover:opacity-50' />
+      </button>
 
       <DropDownMenu
         open={isMenuOpened.v}
@@ -90,14 +92,14 @@ export const PostMenuButton: FC<Props> = ({
 
         {user && (
           <>
-            <div
+            <button
               className='text-left w-full py-2 px-4 hover:bg-primary-light'
               onClick={isAddBookmarkClicked.toggle}
               onMouseEnter={isHoveringAddBookmark.setTrue}
               onMouseLeave={isHoveringAddBookmark.setFalse}
             >
               ブックマークに追加
-            </div>
+            </button>
 
             {post.bookmark && (
               <button

--- a/src/components/shares/AvatarDropDownMenu.tsx
+++ b/src/components/shares/AvatarDropDownMenu.tsx
@@ -23,13 +23,16 @@ export const HeaderDropDownMenu: FC = () => {
   return (
     <div>
       {/* アバターアイコン */}
-      <div className='cursor-pointer flex' onClick={open.toggle}>
+      <button
+        className='cursor-pointer flex'
+        onClick={open.toggle}
+      >
         {user ? (
           <Avatar id={user.id} />
         ) : (
           <FaUserCircleIcon className='h-9 w-9' />
         )}
-      </div>
+      </button>
 
       <div className='relative'>
         <DropDownMenu

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -39,13 +39,16 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
         <div className='flex justify-between items-center'>
           <div>
             <div className='w-23 whitespace-nowrap sm:(flex gap-5 w-full) '>
-              <Avatar id={Number(userProfile?.user.id)} size='xl' />
+              <Avatar
+                id={Number(userProfile?.user.id)}
+                size='xl'
+              />
               <div>
                 <h1 className='font-bold mt-2 text-2xl'>
                   {userProfile?.user.username}
                 </h1>
                 <div className='flex mt-4 gap-3'>
-                  <div
+                  <button
                     onClick={() => {
                       open.setTrue()
                       setSelected('フォロー一覧')
@@ -57,8 +60,8 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
                       {userProfile.followingCount}
                     </span>{' '}
                     <span className='text-gray-500'>フォロー</span>
-                  </div>
-                  <div
+                  </button>
+                  <button
                     onClick={() => {
                       open.setTrue()
                       setSelected('フォロワー一覧')
@@ -70,7 +73,7 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
                       {userProfile.followerCount}
                     </span>{' '}
                     <span className='text-gray-500'>フォロワー</span>
-                  </div>
+                  </button>
                   <p>
                     <span className='font-bold'>
                       {userProfile?.posts.length}
@@ -129,7 +132,7 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
           <div className='w-full px-2 gap-3'>
             <div className='border-b flex border-gray-300'>
               {modalTabs.map(tab => (
-                <div
+                <button
                   key={tab}
                   className={`cursor-pointer text-lg text-center pb-1 w-50vw ${
                     tab === selected &&
@@ -144,7 +147,7 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
                   }}
                 >
                   {tab}
-                </div>
+                </button>
               ))}
             </div>
           </div>


### PR DESCRIPTION
## 関連 Issue

- #151  
- #155 

## 詳細

- PostLinkCardはoverflow-hiddenのせいでフォーカスが見えなかったので修正

以下をbuttonタグに変更
- PostItemの・・・
  - ブックマークに追加
- ヘッダーのユーザーアイコン
- ユーザーページの フォロー数、フォロワー数
- フォローフォロワー一覧モーダルの、タグ

## 悩み
- 表示するモーダルに閉じるボタンがほぼ無くて、タブ操作でモーダルを閉じることが出来ない。でもEscを押すと閉じるから、閉じるボタン要らない？
- PostItemのコメントが今のままだとタブでフォーカスされないから、別issueにする


## 動作確認
![image](https://user-images.githubusercontent.com/88410576/227452244-2ce25a22-6b0a-4e58-976b-c56d487b37ab.png)

![image](https://user-images.githubusercontent.com/88410576/227452271-f68dfc65-a358-47e2-962a-561553ba4565.png)

![image](https://user-images.githubusercontent.com/88410576/227452324-5bf9b505-229f-4510-a498-90a90afbd0bf.png)


![image](https://user-images.githubusercontent.com/88410576/227452459-cc766eae-5911-4345-9f9a-3a7a8b352945.png)


![image](https://user-images.githubusercontent.com/88410576/227452548-e03cbea6-e29e-417c-a140-ee66848aeb1b.png)


![image](https://user-images.githubusercontent.com/88410576/227452587-cf513600-6379-44fb-b92d-ecc7da0ac723.png)


