### PR TITLE
dprintの導入

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,7 @@
     "next",
     "next/core-web-vitals",
     "plugin:import/recommended",
-    "plugin:react-hooks/recommended",
-    "prettier"
+    "plugin:react-hooks/recommended"
   ],
   "overrides": [
     {

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm type-check && pnpm lint
+pnpm type-check

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{ts,tsx,js,jsx}": ["eslint --fix"]
+  "*.{ts,tsx,js,jsx}": ["eslint --fix", "dprint fmt"]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "jsxSingleQuote": true,
-  "trailingComma": "all",
-  "arrowParens": "avoid"
-}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "esbenp.prettier-vscode",
+    "dprint.dprint",
     "dbaeumer.vscode-eslint",
     "streetsidesoftware.code-spell-checker",
     "voorjaar.windicss-intellisense"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
-  "editor.tabSize": 2,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "dprint.dprint",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,22 @@
+{
+  "incremental": true,
+  "lineWidth": 80,
+  "indentWidth": 2,
+  "typescript": {
+    "quoteStyle": "alwaysSingle",
+    "semiColons": "asi",
+    "arrowFunction.useParentheses": "force",
+    "binaryExpression.linePerExpression": false,
+    "useBraces": "always"
+  },
+  "json": {},
+  "excludes": [
+    "**/node_modules",
+    "**/*-lock.json",
+    "**/.next"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.87.1.wasm",
+    "https://plugins.dprint.dev/json-0.17.4.wasm"
+  ]
+}

--- a/dprint.json
+++ b/dprint.json
@@ -5,9 +5,10 @@
   "typescript": {
     "quoteStyle": "alwaysSingle",
     "semiColons": "asi",
-    "arrowFunction.useParentheses": "force",
-    "binaryExpression.linePerExpression": false,
-    "useBraces": "always"
+    "arrowFunction.useParentheses": "preferNone",
+    "importDeclaration.sortNamedImports": "maintain",
+    "module.sortImportDeclarations": "maintain",
+    "ignoreFileCommentText": "dprint-ignore"
   },
   "json": {},
   "excludes": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "dprint": "^0.41.0",
     "eslint": "8.17.0",
     "eslint-config-next": "^13.0.5",
-    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react-hooks": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "fmt": "pnpm dprint fmt",
     "type-check": "tsc --noEmit",
     "co": "git-cz"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/react": "18.0.12",
     "@types/react-dom": "18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
+    "dprint": "^0.41.0",
     "eslint": "8.17.0",
     "eslint-config-next": "^13.0.5",
     "eslint-config-prettier": "^8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ devDependencies:
   eslint-config-next:
     specifier: ^13.0.5
     version: 13.0.5(eslint@8.17.0)(typescript@4.7.3)
-  eslint-config-prettier:
-    specifier: ^8.5.0
-    version: 8.5.0(eslint@8.17.0)
   eslint-plugin-filenames:
     specifier: ^1.3.2
     version: 1.3.2(eslint@8.17.0)
@@ -1581,15 +1578,6 @@ packages:
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
-
-  /eslint-config-prettier@8.5.0(eslint@8.17.0):
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
-    dependencies:
-      eslint: 8.17.0
     dev: true
 
   /eslint-import-resolver-node@0.3.9:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ devDependencies:
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.56.0
     version: 5.56.0(@typescript-eslint/parser@5.62.0)(eslint@8.17.0)(typescript@4.7.3)
+  dprint:
+    specifier: ^0.41.0
+    version: 0.41.0
   eslint:
     specifier: 8.17.0
     version: 8.17.0
@@ -317,6 +320,54 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     dev: false
+
+  /@dprint/darwin-arm64@0.41.0:
+    resolution: {integrity: sha512-P9PtcQI0mrI4U6yyd+/iI664BHSqC9KTS6ogq0ptEdnLtlaWzf09D1nv6FBaHiG9m3conuBRlPsoUqt3j6PZ2w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/darwin-x64@0.41.0:
+    resolution: {integrity: sha512-mSYnSoH0uyCkjgIWTny2DZAcaiRTe3kRWY5SeZECLGO37e+SdVg+ZjSzndhOvvEb9pv8EeBO1NJ9gHOSceT5Xw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/linux-arm64-glibc@0.41.0:
+    resolution: {integrity: sha512-U4xWzjjO/aAct8cSSMZFhg8l1jWy6VahXh8zWjGBufwX7t3xEcxMG9RyAp/ioYSY6wl4YXAmnUHywhC+wSjDHQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/linux-x64-glibc@0.41.0:
+    resolution: {integrity: sha512-wjv5l4mGns7E8i32E8FfAk45tw5O7v4NM17gtvhe6ggOiOD6quHowOH00pLfEakMLMF9y0J5ZO2hxJ/w06bXmQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/linux-x64-musl@0.41.0:
+    resolution: {integrity: sha512-ZZOqiur9Xi/2uhz0Ce215VTSajAlSrduX/5k/hpIjI7Rgz22Vn77p5fmYxzWkTt/Li1zq5zboTvmGYx0QVNMrQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/win32-x64@0.41.0:
+    resolution: {integrity: sha512-mFx6x4Hn848/D4gPbDm7g1wlnOh2SGoVF9c9HMGCuOobUU2WIBztzV4L5qlFCB3gprlS0ru9BhlMpGhrp0CBYA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.17.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -1359,6 +1410,19 @@ packages:
     dependencies:
       is-obj: 2.0.0
     dev: false
+
+  /dprint@0.41.0:
+    resolution: {integrity: sha512-9Ctv6EnwOy5Ai566DczI/QhAC6y+AhWDA2gFU8Zz4xezUy1BevHaIYhfdLWZQxh4Qf4H28lRu1Lq+hhIm1US9w==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@dprint/darwin-arm64': 0.41.0
+      '@dprint/darwin-x64': 0.41.0
+      '@dprint/linux-arm64-glibc': 0.41.0
+      '@dprint/linux-x64-glibc': 0.41.0
+      '@dprint/linux-x64-musl': 0.41.0
+      '@dprint/win32-x64': 0.41.0
+    dev: true
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}

--- a/src/components/bookmark/BookmarkFolderEditModal.tsx
+++ b/src/components/bookmark/BookmarkFolderEditModal.tsx
@@ -45,11 +45,12 @@ export const BookmarkFolderEditModal: FC<Props> = ({
     resolver: zodResolver(schema),
   })
 
-  const { onSubmit, errorMessage, clearErrorMessage } =
-    useFormErrorHandling<FormData>(async (e: FormData) => {
-      await onUpdateFolder?.(e.name)
-      onClose()
-    })
+  const { onSubmit, errorMessage, clearErrorMessage } = useFormErrorHandling<
+    FormData
+  >(async (e: FormData) => {
+    await onUpdateFolder?.(e.name)
+    onClose()
+  })
 
   return (
     <div>

--- a/src/components/bookmark/BookmarkFolderList.tsx
+++ b/src/components/bookmark/BookmarkFolderList.tsx
@@ -38,10 +38,8 @@ export const BookmarkFolderList: FC<Props> = ({ folders }) => {
   return (
     <div>
       {/* ブックマーク名一覧 */}
-      <ul
-        className='bg-primary-light flex h-50px gap-2 overflow-x-scroll scroll-bar
-                  sm:(flex-col gap-1 h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll) '
-      >
+      <ul className='bg-primary-light flex h-50px gap-2 overflow-x-scroll scroll-bar
+                  sm:(flex-col gap-1 h-auto min-w-190px max-w-190px max-h-[calc(100vh-250px)] overflow-x-hidden overflow-y-scroll) '>
         {/* スマホ横スクロールで左右に余分を空けている */}
         <div className='ml-2 sm:hidden' />
 
@@ -78,14 +76,14 @@ export const BookmarkFolderList: FC<Props> = ({ folders }) => {
           onClose={isModalOpened.setFalse}
           folder={folders[routerFolderIndex]}
           onUpdateFolder={async (folderName: string) =>
-            await updateFolder(folders[routerFolderIndex].id, folderName)
-          }
+            await updateFolder(folders[routerFolderIndex].id, folderName)}
           onDeleteFolder={async () => {
             await deleteFolder(folders[routerFolderIndex].id)
           }}
         />
       )}
-      <style jsx>{`
+      <style jsx>
+        {`
         .scroll-bar::-webkit-scrollbar {
           width: 0;
           height: 0;
@@ -103,7 +101,8 @@ export const BookmarkFolderList: FC<Props> = ({ folders }) => {
           border-radius: 100px;
           background-color: ${primary.dark};
         }
-      `}</style>
+      `}
+      </style>
     </div>
   )
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -43,36 +43,38 @@ export const Header: FC = () => {
             tabIndex={0}
           />
 
-          {isLoggedIn ? (
-            <div className='flex gap-3 items-center'>
-              <HeaderDropDownMenu />
+          {isLoggedIn
+            ? (
+              <div className='flex gap-3 items-center'>
+                <HeaderDropDownMenu />
 
-              {pathname !== '/create' && (
-                <Link href='/create' aria-label='記事をシェアする'>
-                  <Button
-                    className='hidden sm:block'
-                    radius='md'
-                    size='lg'
-                    color='accent'
-                    compact
-                    animate
-                    rightIcon={
-                      <HiPaperAirplaneIcon className='transform rotate-90' />
-                    }
-                  >
-                    シェアする
-                  </Button>
+                {pathname !== '/create' && (
+                  <Link href='/create' aria-label='記事をシェアする'>
+                    <Button
+                      className='hidden sm:block'
+                      radius='md'
+                      size='lg'
+                      color='accent'
+                      compact
+                      animate
+                      rightIcon={
+                        <HiPaperAirplaneIcon className='transform rotate-90' />
+                      }
+                    >
+                      シェアする
+                    </Button>
+                  </Link>
+                )}
+              </div>
+            )
+            : (
+              <div className='flex gap-2 items-center'>
+                <Link href='/login'>ログイン</Link>
+                <Link href='/signup'>
+                  <Button>新規登録</Button>
                 </Link>
-              )}
-            </div>
-          ) : (
-            <div className='flex gap-2 items-center'>
-              <Link href='/login'>ログイン</Link>
-              <Link href='/signup'>
-                <Button>新規登録</Button>
-              </Link>
-            </div>
-          )}
+              </div>
+            )}
         </div>
       </nav>
     </header>

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -50,11 +50,13 @@ export const PostForm: FC<Props> = ({
 
   return (
     <div className='flex flex-col items-center justify-center'>
-      <style jsx>{`
+      <style jsx>
+        {`
         .scroll-bar-none::-webkit-scrollbar {
           display: none;
         }
-      `}</style>
+      `}
+      </style>
 
       <form
         onSubmit={handleSubmit(onSubmit)}
@@ -115,8 +117,7 @@ export const PostForm: FC<Props> = ({
                 onClick={() =>
                   setValue('published', !getValues('published'), {
                     shouldValidate: true,
-                  })
-                }
+                  })}
               >
                 <div className='font-bold text-white top-[2px] left-[5px] absolute'>
                   公開
@@ -130,7 +131,8 @@ export const PostForm: FC<Props> = ({
                       ? 'left-40px w-46px'
                       : 'left-3px w-38px'
                   } duration-150 absolute`}
-                ></div>
+                >
+                </div>
               </button>
             </div>
           </label>

--- a/src/components/post/PostItem.tsx
+++ b/src/components/post/PostItem.tsx
@@ -49,48 +49,50 @@ export const PostItem: FC<Props> = ({ post, folderId = '' }) => {
 
       {/* 編集中ならtextarea それ以外は コメント表示 */}
       <div className='mt-3'>
-        {isEditing.v ? (
-          <div className='mx-1'>
-            <PostForm
-              onSubmit={async params => {
-                await updatePost(params)
-                isEditing.setFalse()
-              }}
-              formParamsProps={post}
-              submitButtonText='更新'
-            />
-            <Button
-              color='secondary'
-              fullWidth
-              className='mt-2'
-              onClick={isEditing.setFalse}
-            >
-              キャンセル
-            </Button>
-          </div>
-        ) : (
-          <>
-            <PostItemComment comment={post.comment} />
-
-            <div className='mt-2'>
-              <PostLinkCard post={post} />
+        {isEditing.v
+          ? (
+            <div className='mx-1'>
+              <PostForm
+                onSubmit={async params => {
+                  await updatePost(params)
+                  isEditing.setFalse()
+                }}
+                formParamsProps={post}
+                submitButtonText='更新'
+              />
+              <Button
+                color='secondary'
+                fullWidth
+                className='mt-2'
+                onClick={isEditing.setFalse}
+              >
+                キャンセル
+              </Button>
             </div>
+          )
+          : (
+            <>
+              <PostItemComment comment={post.comment} />
 
-            {/* 返信 */}
-            <div className='flex h-6 mt-2 items-center justify-between'>
-              {post.replyComments.length ? (
-                <Link href=''>
-                  <p className='cursor-pointer text-primary-dark'>
-                    {post.replyComments?.length}件の返信
-                  </p>
-                </Link>
-              ) : (
-                <p />
-              )}
-              <p className='text-sm'>{calcHowManyDaysAgo(post.createdAt)}</p>
-            </div>
-          </>
-        )}
+              <div className='mt-2'>
+                <PostLinkCard post={post} />
+              </div>
+
+              {/* 返信 */}
+              <div className='flex h-6 mt-2 items-center justify-between'>
+                {post.replyComments.length
+                  ? (
+                    <Link href=''>
+                      <p className='cursor-pointer text-primary-dark'>
+                        {post.replyComments?.length}件の返信
+                      </p>
+                    </Link>
+                  )
+                  : <p />}
+                <p className='text-sm'>{calcHowManyDaysAgo(post.createdAt)}</p>
+              </div>
+            </>
+          )}
       </div>
     </article>
   )

--- a/src/components/post/PostLinkCard.tsx
+++ b/src/components/post/PostLinkCard.tsx
@@ -17,19 +17,21 @@ export const PostLinkCard: FC<Props> = ({ post }) => {
       >
         <div className='rounded-md border-2 duration-300 overflow-hidden group hover:bg-gray-100 '>
           <div className='flex h-42vw max-h-215px overflow-hidden items-center sm:h-133px'>
-            {post.metaInfo.image ? (
-              // eslint-disable-next-line
-              <img
-                src={post.metaInfo.image}
-                alt='記事のサムネイル'
-                title={`${post.metaInfo?.title}へ移動します`}
-                className='bg-gray-100 transform duration-300 group-hover:scale-110'
-              />
-            ) : (
-              <div className='flex h-full bg-gray-300 text-mono w-full max-h-225px transform text-2xl duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
-                No image
-              </div>
-            )}
+            {post.metaInfo.image
+              ? (
+                // eslint-disable-next-line
+                <img
+                  src={post.metaInfo.image}
+                  alt='記事のサムネイル'
+                  title={`${post.metaInfo?.title}へ移動します`}
+                  className='bg-gray-100 transform duration-300 group-hover:scale-110'
+                />
+              )
+              : (
+                <div className='flex h-full bg-gray-300 text-mono w-full max-h-225px transform text-2xl duration-300 overflow-hidden items-center justify-center group-hover:scale-110'>
+                  No image
+                </div>
+              )}
           </div>
 
           <figcaption className='text-sm p-2'>

--- a/src/components/post/PostStars.tsx
+++ b/src/components/post/PostStars.tsx
@@ -37,9 +37,9 @@ export const PostStars: FC<PostStarProps> = ({ evaluation, onClick }) => {
         >
           <Star
             className='group-hover:(transform scale-125) '
-            color={
-              v <= stars ? (isHovering ? 'bg-yellow-100' : 'bg-yellow-200') : ''
-            }
+            color={v <= stars
+              ? (isHovering ? 'bg-yellow-100' : 'bg-yellow-200')
+              : ''}
           />
         </div>
       ))}

--- a/src/components/shares/AvatarDropDownMenu.tsx
+++ b/src/components/shares/AvatarDropDownMenu.tsx
@@ -29,11 +29,9 @@ export const HeaderDropDownMenu: FC = () => {
         aria-label='メニューを開く'
         aria-pressed={open.v}
       >
-        {user ? (
-          <Avatar id={user.id} />
-        ) : (
-          <FaUserCircleIcon className='h-9 w-9' />
-        )}
+        {user
+          ? <Avatar id={user.id} />
+          : <FaUserCircleIcon className='h-9 w-9' />}
       </button>
 
       <div className='relative'>

--- a/src/components/shares/CreateFolderButton.tsx
+++ b/src/components/shares/CreateFolderButton.tsx
@@ -38,11 +38,12 @@ export const CreateFolderButton: FC<Props> = ({ radius = 'md' }) => {
     resolver: zodResolver(schema),
   })
 
-  const { onSubmit, errorMessage, clearErrorMessage } =
-    useFormErrorHandling<FormData>(async (e: FormData) => {
-      await createFolder(e.name)
-      onClose()
-    })
+  const { onSubmit, errorMessage, clearErrorMessage } = useFormErrorHandling<
+    FormData
+  >(async (e: FormData) => {
+    await createFolder(e.name)
+    onClose()
+  })
 
   const onClose = useCallback(() => {
     open.setFalse()

--- a/src/components/shares/base/Button.tsx
+++ b/src/components/shares/base/Button.tsx
@@ -131,7 +131,8 @@ export const Button: FC<Props> = ({
   }, [radius])
 
   const buttonClass = `${className} ${fullWidthClass}`
-  const spanClass = `${defaultClass} ${colorClass} ${animateClass} ${sizeClass} ${RadiusClass} ${fullWidthClass} `
+  const spanClass =
+    `${defaultClass} ${colorClass} ${animateClass} ${sizeClass} ${RadiusClass} ${fullWidthClass} `
 
   return (
     <button className={buttonClass} onClick={onClick} type={type}>

--- a/src/components/user/UserCard.tsx
+++ b/src/components/user/UserCard.tsx
@@ -36,41 +36,43 @@ export const UserCard: FC<Props> = ({ user, onClickUser }) => {
           </p>
         </div>
       </Link>
-      {currentUser && currentUser.id !== user.id ? (
-        <Button
-          size='xs'
-          radius='xl'
-          variant={isFollowing.v ? 'outline' : 'filled'}
-          animate={isFollowing.v ? false : true}
-          // FollowButtonコンポーネントでいい感じに渡す
-          onClick={
-            isFollowing.v
+      {currentUser && currentUser.id !== user.id
+        ? (
+          <Button
+            size='xs'
+            radius='xl'
+            variant={isFollowing.v ? 'outline' : 'filled'}
+            animate={isFollowing.v ? false : true}
+            // FollowButtonコンポーネントでいい感じに渡す
+            onClick={isFollowing.v
               ? async () => {
-                  isFollowing.setFalse()
-                  await unFollow()
-                }
+                isFollowing.setFalse()
+                await unFollow()
+              }
               : async () => {
-                  isFollowing.setTrue()
-                  await follow()
-                }
-          }
-        >
-          <span aria-live='polite'>
-            {isFollowing.v ? 'フォロー中' : 'フォロー'}
-          </span>
-        </Button>
-      ) : (
-        ''
-      )}
+                isFollowing.setTrue()
+                await follow()
+              }}
+          >
+            <span aria-live='polite'>
+              {isFollowing.v ? 'フォロー中' : 'フォロー'}
+            </span>
+          </Button>
+        )
+        : (
+          ''
+        )}
 
       {/* 長い文字を...にする */}
-      <style jsx>{`
+      <style jsx>
+        {`
         .text-overflow {
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
         }
-      `}</style>
+      `}
+      </style>
     </div>
   )
 }

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -25,8 +25,9 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
 
   // モーダル
   const open = useBoolean(false)
-  const [selected, setSelected] =
-    useState<(typeof modalTabs)[number]>('フォロー一覧')
+  const [selected, setSelected] = useState<(typeof modalTabs)[number]>(
+    'フォロー一覧',
+  )
 
   const { data: followers, mutate: mutateFollowers } = useGetApi<UserInfo[]>(
     `/users/${userProfile?.user.id}/followers`,
@@ -86,31 +87,35 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
 
           <div className='transform translate-y-[-42px] sm:translate-y-0'>
             {/* aria-live付けたい */}
-            {currentUser ? (
-              isMyPage ? (
-                <Button
-                  radius='xs'
-                  variant='neumorphism'
-                  className='whitespace-nowrap'
-                >
-                  プロフィールを編集
-                </Button>
-              ) : (
-                <Button
-                  size='md'
-                  radius='xl'
-                  variant={userProfile.isFollowing ? 'outline' : 'filled'}
-                  animate={userProfile.isFollowing ? false : true}
-                  onClick={userProfile.isFollowing ? unFollow : follow}
-                >
-                  <span aria-live='polite'>
-                    {userProfile.isFollowing ? 'フォロー中' : 'フォロー'}
-                  </span>
-                </Button>
+            {currentUser
+              ? (
+                isMyPage
+                  ? (
+                    <Button
+                      radius='xs'
+                      variant='neumorphism'
+                      className='whitespace-nowrap'
+                    >
+                      プロフィールを編集
+                    </Button>
+                  )
+                  : (
+                    <Button
+                      size='md'
+                      radius='xl'
+                      variant={userProfile.isFollowing ? 'outline' : 'filled'}
+                      animate={userProfile.isFollowing ? false : true}
+                      onClick={userProfile.isFollowing ? unFollow : follow}
+                    >
+                      <span aria-live='polite'>
+                        {userProfile.isFollowing ? 'フォロー中' : 'フォロー'}
+                      </span>
+                    </Button>
+                  )
               )
-            ) : (
-              ''
-            )}
+              : (
+                ''
+              )}
           </div>
         </div>
       </section>
@@ -131,8 +136,8 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
                 role='tab'
                 aria-selected={selected === tab}
                 className={`cursor-pointer text-lg text-center pb-1 w-50vw ${
-                  tab === selected &&
-                  'border-primary-dark border-b-3 text-primary-dark'
+                  tab === selected
+                  && 'border-primary-dark border-b-3 text-primary-dark'
                 }`}
                 onClick={() => {
                   setSelected(tab)
@@ -149,29 +154,31 @@ export const UserProfile: FC<Props> = ({ userProfile, isMyPage }) => {
         }
       >
         <div className='bg-white rounded-lg flex flex-col py-6 px-4 gap-6'>
-          {selected === 'フォロワー一覧' ? (
-            followers?.length ? (
-              followers.map(user => (
+          {selected === 'フォロワー一覧'
+            ? (
+              followers?.length
+                ? (
+                  followers.map(user => (
+                    <UserCard
+                      key={`${user.id} ${user.isFollowing}`}
+                      user={user}
+                      onClickUser={open.setFalse}
+                    />
+                  ))
+                )
+                : <p className='text-center'>フォロワーはいません</p>
+            )
+            : followings?.length
+            ? (
+              followings.map(user => (
                 <UserCard
                   key={`${user.id} ${user.isFollowing}`}
                   user={user}
                   onClickUser={open.setFalse}
                 />
               ))
-            ) : (
-              <p className='text-center'>フォロワーはいません</p>
             )
-          ) : followings?.length ? (
-            followings.map(user => (
-              <UserCard
-                key={`${user.id} ${user.isFollowing}`}
-                user={user}
-                onClickUser={open.setFalse}
-              />
-            ))
-          ) : (
-            <p className='text-center'>フォローしているユーザーはいません</p>
-          )}
+            : <p className='text-center'>フォローしているユーザーはいません</p>}
         </div>
       </Modal>
     </div>

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -69,8 +69,8 @@ export const useGetInfinite = <Data = any>(
 
   // 最後に到達した
   const isEmpty = data?.[0].length === 0
-  const isReachingEnd =
-    isEmpty || (data && data?.[data?.length - 1]?.length < limit)
+  const isReachingEnd = isEmpty
+    || (data && data?.[data?.length - 1]?.length < limit)
 
   // もっと読み込む
   const fetchMore = useCallback(() => {

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -25,18 +25,18 @@ export function useResizeObserver<T extends HTMLElement = any>() {
     () =>
       browser
         ? new ResizeObserver((entries: any) => {
-            const entry = entries[0]
+          const entry = entries[0]
 
-            if (entry) {
-              cancelAnimationFrame(frameID.current)
+          if (entry) {
+            cancelAnimationFrame(frameID.current)
 
-              frameID.current = requestAnimationFrame(() => {
-                if (ref.current) {
-                  setRect(entry.contentRect)
-                }
-              })
-            }
-          })
+            frameID.current = requestAnimationFrame(() => {
+              if (ref.current) {
+                setRect(entry.contentRect)
+              }
+            })
+          }
+        })
         : null,
     [],
   )

--- a/src/hooks/useFolder.ts
+++ b/src/hooks/useFolder.ts
@@ -8,8 +8,9 @@ import { getStatusErrorMessage } from 'utils/getStatusErrorMessage'
 import { useGetApi } from './useApi'
 
 export const useCreateFolder = () => {
-  const { data: folders, mutate: mutateFolders } =
-    useGetApi<Folder[]>('/folders')
+  const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
+    '/folders',
+  )
 
   const createFolder = useCallback(
     async (bookmarkName: string) => {
@@ -35,8 +36,9 @@ export const useCreateFolder = () => {
 }
 
 export const useUpdateFolder = () => {
-  const { data: folders, mutate: mutateFolders } =
-    useGetApi<Folder[]>('/folders')
+  const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
+    '/folders',
+  )
 
   const updateFolder = useCallback(
     async (id: string, editFolderName: string) => {
@@ -71,8 +73,9 @@ export const useUpdateFolder = () => {
 
 export const useDeleteFolder = () => {
   const router = useRouter()
-  const { data: folders, mutate: mutateFolders } =
-    useGetApi<Folder[]>('/folders')
+  const { data: folders, mutate: mutateFolders } = useGetApi<Folder[]>(
+    '/folders',
+  )
 
   const deleteFolder = useCallback(
     async (id: string) => {

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -7,8 +7,9 @@ import { useGetApi } from './useApi'
 
 export const useFollow = (id: number) => {
   // フォローされたユーザー、自分のuserProfile
-  const { data: userProfile, mutate: mutateUserProfile } =
-    useGetApi<UserProfile>(`/users/${id}`)
+  const { data: userProfile, mutate: mutateUserProfile } = useGetApi<
+    UserProfile
+  >(`/users/${id}`)
   const { data: currentUser } = useGetApi<User>('/users/me')
   const { data: currentUserProfile, mutate: mutateCurrentUserProfile } =
     useGetApi<UserProfile>(`/users/${currentUser?.id}`)
@@ -60,8 +61,9 @@ export const useFollow = (id: number) => {
 
 export const useUnFollow = (id: number) => {
   // フォローされたユーザー、自分のuserProfile
-  const { data: userProfile, mutate: mutateUserProfile } =
-    useGetApi<UserProfile>(`/users/${id}`)
+  const { data: userProfile, mutate: mutateUserProfile } = useGetApi<
+    UserProfile
+  >(`/users/${id}`)
   const { data: currentUser } = useGetApi<User>('/users/me')
   const { data: currentUserProfile, mutate: mutateCurrentUserProfile } =
     useGetApi<UserProfile>(`/users/${currentUser?.id}`)

--- a/src/pages/bookmark.tsx
+++ b/src/pages/bookmark.tsx
@@ -72,23 +72,25 @@ const Bookmark: NextPage = () => {
         </div>
 
         {/* 選択しているフォルダの記事一覧 */}
-        {bookmarkPosts?.posts.length && folders ? (
-          <div className='mt-12 w-full sm:mt-21'>
-            <div className='grid gap-6 justify-center items-start sm:(gap-x-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
-              {bookmarkPosts.posts.map((post, index) => (
-                <PostItem
-                  key={index}
-                  post={post}
-                  // Postはどのフォルダに居るか知らない
-                  folderId={folders[selectedFolderIndex].id}
-                />
-              ))}
+        {bookmarkPosts?.posts.length && folders
+          ? (
+            <div className='mt-12 w-full sm:mt-21'>
+              <div className='grid gap-6 justify-center items-start sm:(gap-x-3 grid-cols-[repeat(auto-fill,minmax(291px,auto))]) '>
+                {bookmarkPosts.posts.map((post, index) => (
+                  <PostItem
+                    key={index}
+                    post={post}
+                    // Postはどのフォルダに居るか知らない
+                    folderId={folders[selectedFolderIndex].id}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        ) : (
-          // 記事が無い
-          <div className='mt-20 text-center w-full'>記事がありません</div>
-        )}
+          )
+          : (
+            // 記事が無い
+            <div className='mt-20 text-center w-full'>記事がありません</div>
+          )}
       </div>
     </Layout>
   )

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -11,8 +11,9 @@ import { useCreatePost } from 'hooks/usePost'
 const Create: NextPage = () => {
   useRequireLogin()
   const { createPost } = useCreatePost()
-  const { onSubmit, errorMessage, clearErrorMessage } =
-    useFormErrorHandling<PostRequestParams>(createPost)
+  const { onSubmit, errorMessage, clearErrorMessage } = useFormErrorHandling<
+    PostRequestParams
+  >(createPost)
 
   return (
     <>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -11,8 +11,9 @@ import { useLogin } from '../hooks/login/useAuth'
 
 const Login: NextPage = () => {
   const { login } = useLogin()
-  const { onSubmit, errorMessage, clearErrorMessage } =
-    useFormErrorHandling<LoginRequestParams>(login)
+  const { onSubmit, errorMessage, clearErrorMessage } = useFormErrorHandling<
+    LoginRequestParams
+  >(login)
 
   return (
     <>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -10,8 +10,9 @@ import { useFormErrorHandling } from 'hooks/useFormErrorHandling'
 
 const SignUp: NextPage = () => {
   const { signUp } = useSignUp()
-  const { onSubmit, errorMessage, clearErrorMessage } =
-    useFormErrorHandling<SignUpRequestParams>(signUp)
+  const { onSubmit, errorMessage, clearErrorMessage } = useFormErrorHandling<
+    SignUpRequestParams
+  >(signUp)
 
   return (
     <>

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -48,8 +48,8 @@ const User: NextPage = () => {
                 aria-selected={selected === tab}
                 onClick={() => setSelected(tab)}
                 className={`text-xl pb-1 w-50vw sm:w-100px ${
-                  selected === tab &&
-                  'font-bold border-b-3 border-primary-dark text-primary-dark'
+                  selected === tab
+                  && 'font-bold border-b-3 border-primary-dark text-primary-dark'
                 }`}
               >
                 {tab}

--- a/src/stores/useCookies.ts
+++ b/src/stores/useCookies.ts
@@ -40,7 +40,7 @@ export const useCookies = <
         removeCookie(key)
         return
       }
-      key.forEach((v) => {
+      key.forEach(v => {
         return removeCookie(v)
       })
     },

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -46,9 +46,11 @@ export const fetchApi = async <T>(
   if (method === 'GET') {
     // /example/1 -> /example/1?searchWord="あああ"
     if (!isEmptyObj(requestParams)) {
-      requestUrl += `?${Object.entries(requestParams)
-        .map(([key, value]) => `${key}=${value}`)
-        .join('&')}`
+      requestUrl += `?${
+        Object.entries(requestParams)
+          .map(([key, value]) => `${key}=${value}`)
+          .join('&')
+      }`
       requestParams = {}
     }
   }

--- a/src/utils/toCamelCaseObj.ts
+++ b/src/utils/toCamelCaseObj.ts
@@ -5,7 +5,7 @@ export const toCamelCase = (str: string) => {
     .map((segment, i) =>
       i === 0
         ? segment.toLowerCase()
-        : segment[0].toUpperCase() + segment.slice(1).toLowerCase(),
+        : segment[0].toUpperCase() + segment.slice(1).toLowerCase()
     )
     .join('')
 }
@@ -15,7 +15,7 @@ export const toCamelCaseObj = (_obj: Record<any, any>) => {
   const obj = { ..._obj } as Record<string, any>
   const result: Record<string, Record<string, any> | []> = {}
 
-  Object.keys(obj).forEach((key) => {
+  Object.keys(obj).forEach(key => {
     if (typeof obj[key] !== 'object') {
       result[toCamelCase(key)] = obj[key]
       return
@@ -23,8 +23,8 @@ export const toCamelCaseObj = (_obj: Record<any, any>) => {
 
     Array.isArray(obj[key])
       ? (result[toCamelCase(key)] = obj[key].map((v: object) =>
-          toCamelCaseObj(v),
-        ))
+        toCamelCaseObj(v)
+      ))
       : (result[toCamelCase(key)] = toCamelCaseObj(obj[key]))
   })
 


### PR DESCRIPTION
## 詳細

- [dprint詳細（Notion）](https://www.notion.so/dprint-ef272ae470d146b088157867d7c7a433)
- [dprint良い記事](https://zenn.dev/ako/articles/654ea7e15638bc)

- dprintの導入、prettierを剥がす
- scriptsに追加
- lintstagedに追加

```json
{
  "lineWidth": 80, // 折り返しの横幅
  "indentWidth": 2, // インデントの幅
  "typescript": {
    "quoteStyle": "alwaysSingle", // シングルクォーテーションを使用
    "semiColons": "asi", // セミコロンを使わない
    "arrowFunction.useParentheses": "preferNone", // アロー関数の引数が1つなら()を付けない
    "importDeclaration.sortNamedImports": "maintain", // import {} の中身をアルファベット順にソートしない
    "module.sortImportDeclarations": "maintain", // importの行の順をアルファベット順にソートしない
    "ignoreFileCommentText": "dprint-ignore" // コメントでdprint-ignoreと書くと下の行を無効化する（デフォルトだが、忘れそうなので設定）
  },
  "json": {},
  "excludes": [
    "**/node_modules",
    "**/*-lock.json",
    "**/.next"
  ],
  "plugins": [
    "https://plugins.dprint.dev/typescript-0.87.1.wasm",
    "https://plugins.dprint.dev/json-0.17.4.wasm"
  ]
}
```

## 動作確認
